### PR TITLE
Add SOS sharing with geolocation and email fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ npm run build
 
 - Home page with "CareBee" title and an SOS button.
 - `/sos` page containing a form with name, e-mail, and message fields.
+- `sendSOS` reads your geolocation and tries the Web Share API. If sharing is
+  unavailable, it opens an e-mail draft and copies the message to the clipboard.
+  If location access is denied, the message is sent without coordinates.
+
+## Notes on Geolocation and Sharing
+
+The SOS feature relies on browser APIs that work only in secure contexts. When
+deployed on GitHub Pages the site is served over HTTPS, but desktop browsers may
+block `navigator.share` or clipboard access. In those cases the app falls back
+to creating a `mailto:` link with the prepared SOS message.
 
 ## Deployment
 

--- a/src/pages/Sos.jsx
+++ b/src/pages/Sos.jsx
@@ -2,15 +2,58 @@ import { useState } from 'react'
 
 export default function Sos() {
   const [form, setForm] = useState({ name: '', email: '', message: '' })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
 
   const handleChange = (e) => {
     const { name, value } = e.target
     setForm((prev) => ({ ...prev, [name]: value }))
   }
 
+  const sendSOS = async () => {
+    setLoading(true)
+    setError('')
+    const { name, email, message } = form
+
+    let coords
+    try {
+      coords = await new Promise((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(
+          (pos) => resolve({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
+          reject
+        )
+      })
+    } catch (err) {
+      setError(err.message)
+    }
+
+    const mapLink = coords ? `https://maps.google.com/?q=${coords.lat},${coords.lon}` : ''
+    const text = `SOS from CareBee: ${name} ${email}. ${message}.` +
+      (coords ? ` Location: ${coords.lat},${coords.lon} ${mapLink}` : '')
+
+    try {
+      if (navigator.share) {
+        await navigator.share({ title: 'SOS', text, url: mapLink || undefined })
+        setLoading(false)
+        return
+      }
+    } catch {
+      // fall back to mailto
+    }
+
+    const mailto = `mailto:?subject=SOS%20CareBee&body=${encodeURIComponent(text)}`
+    window.location.href = mailto
+
+    try {
+      await navigator.clipboard.writeText(text)
+    } catch { /* ignore */ }
+
+    setLoading(false)
+  }
+
   const handleSubmit = (e) => {
     e.preventDefault()
-    console.log(form)
+    sendSOS()
   }
 
   return (
@@ -33,7 +76,9 @@ export default function Sos() {
           <textarea name="message" value={form.message} onChange={handleChange} />
         </label>
       </div>
-      <button type="submit">Send</button>
+      {loading && <p>Loading...</p>}
+      {error && <p>{error}</p>}
+      <button type="submit" disabled={loading}>Send</button>
     </form>
   )
 }


### PR DESCRIPTION
## Summary
- implement sendSOS with geolocation, Web Share API and email/clipboard fallback
- document SOS geolocation usage and GitHub Pages limitations

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a88320382083239002c7364c11fbed