### PR TITLE
Ensure visit title localization and clean lint

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -44,7 +44,7 @@
     "activate": "Activer"
   },
   "visits": {
-    "title": "Visites chez le médecin",
+    "title": "Visites médicales",
     "add": "Ajouter une visite",
     "doctor": "Médecin",
     "place": "Lieu",

--- a/src/pages/Meds.jsx
+++ b/src/pages/Meds.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 const STORAGE = 'carebee.meds'
 const load = (k, def) => { try { const v=localStorage.getItem(k); return v?JSON.parse(v):def } catch { return def } }
-const save = (k, v) => { try { localStorage.setItem(k, JSON.stringify(v)) } catch {} }
+const save = (k, v) => { try { localStorage.setItem(k, JSON.stringify(v)) } catch { /* ignore */ } }
 
 export default function Meds(){
   const { t } = useTranslation()

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 const KEY = 'carebee.profile'
 const load = () => { try { const v = localStorage.getItem(KEY); return v ? JSON.parse(v) : {} } catch { return {} } }
-const save = (obj) => { try { localStorage.setItem(KEY, JSON.stringify(obj)) } catch {} }
+const save = (obj) => { try { localStorage.setItem(KEY, JSON.stringify(obj)) } catch { /* ignore */ } }
 
 export default function Profile() {
   const { t } = useTranslation()

--- a/src/pages/Visits.jsx
+++ b/src/pages/Visits.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 const STORAGE = 'carebee.visits'
 const load = (k, def) => { try { const v=localStorage.getItem(k); return v?JSON.parse(v):def } catch { return def } }
-const save = (k, v) => { try { localStorage.setItem(k, JSON.stringify(v)) } catch {} }
+const save = (k, v) => { try { localStorage.setItem(k, JSON.stringify(v)) } catch { /* ignore */ } }
 
 const todayISO = () => { const d=new Date(); const y=d.getFullYear(); const m=String(d.getMonth()+1).padStart(2,'0'); const day=String(d.getDate()).padStart(2,'0'); return `${y}-${m}-${day}` }
 function toICSDateTime(isoDate, hhmm){


### PR DESCRIPTION
## Summary
- translate French visit titles to "Visites médicales"
- add ignore comments to empty localStorage catch blocks so lint passes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8e97e8388832382e6a88df0696842