### PR TITLE
Add JSON export/import for visits

### DIFF
--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -48,6 +48,9 @@
     "add": "Добавить визит",
     "doctor": "Врач",
     "place": "Место",
+    "exportJson": "Экспорт JSON",
+    "importJson": "Импорт JSON",
+    "invalidFile": "Неверный файл",
     "upcoming": "Ближайшие",
     "empty": "Нет визитов",
     "addToCalendar": "В календарь"


### PR DESCRIPTION
## Summary
- allow visit list to be exported/imported via JSON files
- add Russian translations for new visit import/export buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ebc0b61c83238032d06978f3077b