### PR TITLE
feat: add QR, Vitals (charts), and Docs (IndexedDB) pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
       "name": "carebee",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.0",
+        "dexie": "^4.2.0",
         "i18next": "^25.4.0",
+        "qrcode": "^1.5.4",
         "react": "^19.1.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.1",
         "react-i18next": "^15.7.1",
         "react-router-dom": "^7.8.1"
@@ -1032,6 +1036,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.32",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.32.tgz",
@@ -1459,11 +1469,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1543,6 +1561,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001737",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
@@ -1581,11 +1608,33 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1598,7 +1647,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -1664,11 +1712,32 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.0.tgz",
+      "integrity": "sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -1677,6 +1746,12 @@
       "integrity": "sha512-ozZyibehoe7tOhNaf16lKmljVf+3npZcJIEbJRVftVsmAg5TeA1mGS9dVCZzOwr2xT7xK15V0p7+GZqSPgkuPg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.9",
@@ -2036,6 +2111,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2157,6 +2241,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2406,6 +2499,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2423,7 +2525,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2457,6 +2558,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -2508,6 +2618,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -2515,6 +2642,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -2603,6 +2740,21 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2669,6 +2821,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
@@ -2706,6 +2864,32 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2905,6 +3089,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -2915,12 +3105,119 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.4.0",
+    "dexie": "^4.0.0",
     "i18next": "^25.4.0",
+    "qrcode": "^1.5.0",
     "react": "^19.1.1",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^19.1.1",
     "react-i18next": "^15.7.1",
     "react-router-dom": "^7.8.1"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,9 @@ import Sos from './pages/Sos.jsx'
 import Profile from './pages/Profile.jsx'
 import Meds from './pages/Meds.jsx'
 import Visits from './pages/Visits.jsx'
+import QR from './pages/QR.jsx'
+import Vitals from './pages/Vitals.jsx'
+import Docs from './pages/Docs.jsx'
 export default function App() {
   const { t } = useTranslation()
   const year = new Date().getFullYear()
@@ -18,6 +21,9 @@ export default function App() {
             <Link to="/profile">{t('nav.profile', 'Profile')}</Link>
             <Link to="/meds">{t('nav.meds', 'Meds')}</Link>
             <Link to="/visits">{t('nav.visits', 'Visits')}</Link>
+            <Link to="/qr">QR</Link>
+            <Link to="/vitals">Vitals</Link>
+            <Link to="/docs">Docs</Link>
             <LanguageSwitcher />
           </nav>
         </div>
@@ -30,6 +36,9 @@ export default function App() {
             <Route path="/profile" element={<Profile />} />
             <Route path="/meds" element={<Meds />} />
             <Route path="/visits" element={<Visits />} />
+            <Route path="/qr" element={<QR />} />
+            <Route path="/vitals" element={<Vitals />} />
+            <Route path="/docs" element={<Docs />} />
           </Routes>
         </div>
       </main>

--- a/src/pages/Docs.jsx
+++ b/src/pages/Docs.jsx
@@ -1,0 +1,119 @@
+import Dexie from 'dexie'
+import { useEffect, useState } from 'react'
+
+const db = new Dexie('carebee_docs')
+db.version(1).stores({ files: '++id,name,type,date,tags,note' })
+
+async function addFileRec(file, meta){
+  const blob = file
+  const id = await db.files.add({
+    name: meta.name || file.name,
+    type: meta.type || file.type || 'other',
+    date: meta.date || new Date().toISOString().slice(0,10),
+    tags: meta.tags || '',
+    note: meta.note || '',
+    blob
+  })
+  return id
+}
+
+export default function Docs(){
+  const [list,setList]=useState([])
+  const [busy,setBusy]=useState(false)
+
+  const refresh = async ()=> {
+    const rows = await db.files.toArray()
+    setList(rows.sort((a,b)=> (b.date||'').localeCompare(a.date||'')))
+  }
+  useEffect(()=>{ refresh() },[])
+
+  const onAdd = async (file) => {
+    if(!file) return
+    setBusy(true); await addFileRec(file, {}); setBusy(false); refresh()
+  }
+
+  const toUrl = (blob)=> URL.createObjectURL(blob)
+  const open = (f)=> { const url = toUrl(f.blob); window.open(url, '_blank'); setTimeout(()=>URL.revokeObjectURL(url), 30000) }
+
+  const rename = async (f, name)=> { await db.files.update(f.id,{ name }); refresh() }
+  const remove = async (f)=> { await db.files.delete(f.id); refresh() }
+
+  const blobToDataURL = (blob)=> new Promise(res=>{ const r=new FileReader(); r.onload=()=>res(r.result); r.readAsDataURL(blob) })
+  const exportJSON = async ()=> {
+    const rows = await db.files.toArray()
+    const files = await Promise.all(rows.map(async r=>({
+      id:r.id, name:r.name, type:r.type, date:r.date, tags:r.tags, note:r.note,
+      dataUrl: await blobToDataURL(r.blob)
+    })))
+    const payload = { version:1, files }
+    const a=document.createElement('a')
+    a.href = URL.createObjectURL(new Blob([JSON.stringify(payload,null,2)],{type:'application/json'}))
+    a.download = 'carebee-docs.json'; a.click(); URL.revokeObjectURL(a.href)
+  }
+  const importJSON = (file)=> {
+    const r=new FileReader()
+    r.onload=async ()=>{ try{
+      const data = JSON.parse(r.result)
+      if(!data || !Array.isArray(data.files)) throw new Error()
+      for(const f of data.files){
+        const resp = await fetch(f.dataUrl); const blob = await resp.blob()
+        await addFileRec(new File([blob], f.name, { type: f.type }), f)
+      }
+      refresh()
+    }catch{ alert('Invalid file') } }
+    r.readAsText(file)
+  }
+
+  const share = async (f)=> {
+    try{
+      const fileObj = new File([f.blob], f.name, { type:f.blob.type || 'application/octet-stream' })
+      if(navigator.canShare && navigator.canShare({ files:[fileObj] })){
+        await navigator.share({ files:[fileObj], title:f.name, text:'CareBee document' })
+      }else{
+        open(f)
+      }
+    }catch{}
+  }
+
+  return (
+    <div className="container" style={{maxWidth:900, margin:'0 auto'}}>
+      <h1 className="h1">Documents</h1>
+
+      <div className="card">
+        <div className="row">
+          <label className="btn btn-primary">
+            Add file
+            <input type="file" accept="image/*,.pdf" style={{display:'none'}} onChange={e=>e.target.files[0] && onAdd(e.target.files[0])}/>
+          </label>
+          <button className="btn btn-outline" onClick={exportJSON}>Export JSON</button>
+          <label className="btn btn-outline">
+            Import JSON
+            <input type="file" accept="application/json" style={{display:'none'}} onChange={e=>e.target.files[0] && importJSON(e.target.files[0])}/>
+          </label>
+        </div>
+        {busy && <p>Uploading…</p>}
+      </div>
+
+      <ul>
+        {list.map(f=>(
+          <li key={f.id} className="card" style={{marginTop:12, padding:'12px'}}>
+            <div className="row" style={{justifyContent:'space-between'}}>
+              <div>
+                <strong>{f.name}</strong> — {f.type} — {f.date}
+                {f.tags? <> • {f.tags}</> : null}
+                {f.note? <div style={{color:'#555'}}>{f.note}</div>:null}
+              </div>
+              <div className="row">
+                <button className="btn btn-outline" onClick={()=>open(f)}>Open</button>
+                <button className="btn btn-outline" onClick={()=>share(f)}>Share</button>
+                <button className="btn btn-outline" onClick={()=>rename(f, prompt('New name', f.name) || f.name)}>Rename</button>
+                <button className="btn btn-danger" onClick={()=>remove(f)}>Delete</button>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+

--- a/src/pages/QR.jsx
+++ b/src/pages/QR.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import QRCode from 'qrcode'
+
+const KEY = 'carebee.qr'
+const load = () => { try { const v=localStorage.getItem(KEY); return v?JSON.parse(v):{} } catch { return {} } }
+const save = (o) => { try { localStorage.setItem(KEY, JSON.stringify(o)) } catch {} }
+const loadProfile = () => { try { const v=localStorage.getItem('carebee.profile'); return v?JSON.parse(v):{} } catch { return {} } }
+
+export default function QR(){
+  const { t } = useTranslation()
+  const prof = loadProfile()
+  const [form, setForm] = useState(() => ({
+    allergies:'', conditions:'', meds:'', iceName:'', icePhone:'',
+    includeAge:true, includeAllergies:true, includeMeds:true, includeICE:true,
+    ...load()
+  }))
+  const [png, setPng] = useState('')
+
+  useEffect(()=>save(form),[form])
+
+  const payload = useMemo(()=>{
+    const lines = []
+    const name = [prof.firstName, prof.lastName].filter(Boolean).join(' ')
+    if (name) lines.push(`Name: ${name}`)
+    if (form.includeAge && prof.age) lines.push(`Age: ${prof.age}`)
+    if (form.includeAllergies && form.allergies) lines.push(`Allergies: ${form.allergies}`)
+    if (form.includeMeds && form.meds) lines.push(`Meds: ${form.meds}`)
+    if (form.includeICE && (form.iceName || form.icePhone)) lines.push(`ICE: ${form.iceName || ''} ${form.icePhone || ''}`.trim())
+    if (form.conditions) lines.push(`Notes: ${form.conditions}`)
+    return lines.join('\n').slice(0, 600)
+  }, [form, prof])
+
+  const generate = async () => {
+    const url = await QRCode.toDataURL(payload, { width: 512, margin: 1 })
+    setPng(url)
+  }
+
+  const downloadPNG = () => {
+    if(!png) return
+    const a = document.createElement('a')
+    a.href = png; a.download = 'carebee-qr.png'; a.click()
+  }
+
+  const onChange = (e)=> {
+    const { name, type, checked, value } = e.target
+    setForm(p=>({ ...p, [name]: type==='checkbox' ? checked : value }))
+  }
+
+  return (
+    <div className="container" style={{maxWidth:760, margin:'0 auto'}}>
+      <h1 className="h1">QR — {t('profile.title','Patient profile')}</h1>
+
+      <div className="card">
+        <div className="field"><label>Allergies</label>
+          <textarea name="allergies" value={form.allergies} onChange={onChange} rows={2} placeholder="penicillin, peanuts…" />
+        </div>
+        <div className="field"><label>Important conditions</label>
+          <textarea name="conditions" value={form.conditions} onChange={onChange} rows={2} placeholder="diabetes I, pacemaker…" />
+        </div>
+        <div className="field"><label>Critical meds</label>
+          <textarea name="meds" value={form.meds} onChange={onChange} rows={2} placeholder="Warfarin 5mg…" />
+        </div>
+        <div className="row">
+          <div className="field" style={{flex:1}}>
+            <label>ICE name</label>
+            <input name="iceName" value={form.iceName} onChange={onChange} placeholder="Emergency contact" />
+          </div>
+          <div className="field" style={{flex:1}}>
+            <label>ICE phone</label>
+            <input name="icePhone" value={form.icePhone} onChange={onChange} placeholder="+33…" />
+          </div>
+        </div>
+
+        <div className="row" style={{marginTop:8}}>
+          <label><input type="checkbox" name="includeAge" checked={form.includeAge} onChange={onChange}/> Include age</label>
+          <label><input type="checkbox" name="includeAllergies" checked={form.includeAllergies} onChange={onChange}/> Include allergies</label>
+          <label><input type="checkbox" name="includeMeds" checked={form.includeMeds} onChange={onChange}/> Include meds</label>
+          <label><input type="checkbox" name="includeICE" checked={form.includeICE} onChange={onChange}/> Include ICE</label>
+        </div>
+
+        <div className="row" style={{marginTop:8}}>
+          <button className="btn btn-primary" onClick={generate}>Generate QR</button>
+          <button className="btn btn-outline" onClick={downloadPNG} disabled={!png}>Download PNG</button>
+          <button className="btn btn-outline" onClick={()=>window.print()} disabled={!png}>Print</button>
+        </div>
+      </div>
+
+      {png && (
+        <div style={{textAlign:'center', marginTop:16}}>
+          <img src={png} alt="QR Code" style={{maxWidth:'320px'}} />
+          <pre style={{textAlign:'left', whiteSpace:'pre-wrap', background:'#fff', padding:12, borderRadius:8, border:'1px solid #eee', marginTop:12}}>{payload}</pre>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/src/pages/Vitals.jsx
+++ b/src/pages/Vitals.jsx
@@ -1,0 +1,122 @@
+import { useMemo, useState, useEffect } from 'react'
+import { Line } from 'react-chartjs-2'
+import { CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend, Chart as ChartJS } from 'chart.js'
+import { useTranslation } from 'react-i18next'
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend)
+
+const KEY='carebee.vitals'
+const load=()=>{try{const v=localStorage.getItem(KEY);return v?JSON.parse(v):[]}catch{return[]}}
+const save=(arr)=>{try{localStorage.setItem(KEY,JSON.stringify(arr))}catch{}}
+const nowISO = ()=> new Date().toISOString()
+
+export default function Vitals(){
+  const { t } = useTranslation()
+  const [list,setList]=useState(()=>load())
+  const [type,setType]=useState('bp') // bp | temp | glu
+  const [sys,setSys]=useState(''); const [dia,setDia]=useState(''); const [pulse,setPulse]=useState('')
+  const [temp,setTemp]=useState(''); const [glu,setGlu]=useState(''); const [ts,setTs]=useState(()=>nowISO().slice(0,16))
+
+  useEffect(()=>save(list),[list])
+
+  const add=()=>{
+    const time = ts ? new Date(ts) : new Date()
+    if(type==='bp' && sys && dia){
+      setList(p=>[...p,{id:Date.now(), type, sys:+sys, dia:+dia, pulse:+(pulse||0), at:time.toISOString()}])
+      setSys(''); setDia(''); setPulse('')
+    }else if(type==='temp' && temp){
+      setList(p=>[...p,{id:Date.now(), type, temp:+temp, at:time.toISOString()}]); setTemp('')
+    }else if(type==='glu' && glu){
+      setList(p=>[...p,{id:Date.now(), type, glu:+glu, at:time.toISOString()}]); setGlu('')
+    }
+  }
+  const remove = id => setList(p=>p.filter(x=>x.id!==id))
+  const last = useMemo(()=>[...list].sort((a,b)=>a.at.localeCompare(b.at)).slice(-20),[list])
+
+  const labels = last.map(x=> new Date(x.at).toLocaleString())
+  const bpData = { labels, datasets:[
+    { label:'SYS', data:last.map(x=>x.type==='bp'?x.sys:null), borderWidth:2, spanGaps:true },
+    { label:'DIA', data:last.map(x=>x.type==='bp'?x.dia:null), borderWidth:2, spanGaps:true }
+  ]}
+  const tempData = { labels, datasets:[{ label:'Temp °C', data:last.map(x=>x.type==='temp'?x.temp:null), borderWidth:2, spanGaps:true }] }
+  const gluData  = { labels, datasets:[{ label:'Glucose mmol/L', data:last.map(x=>x.type==='glu'?x.glu:null), borderWidth:2, spanGaps:true }] }
+
+  const exportJSON = () => {
+    const blob = new Blob([JSON.stringify(list,null,2)], {type:'application/json'})
+    const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='vitals.json'; a.click(); URL.revokeObjectURL(a.href)
+  }
+  const exportCSV = () => {
+    const head='type,sys,dia,pulse,temp,glu,at'
+    const rows=list.map(x=>[x.type,x.sys??'',x.dia??'',x.pulse??'',x.temp??'',x.glu??'',x.at].join(','))
+    const blob=new Blob([[head,...rows].join('\n')],{type:'text/csv'})
+    const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='vitals.csv'; a.click(); URL.revokeObjectURL(a.href)
+  }
+  const importJSON = (file) => {
+    const reader=new FileReader()
+    reader.onload=()=>{ try{
+      const arr=JSON.parse(reader.result); if(!Array.isArray(arr)) throw new Error();
+      setList(arr); }catch{ alert('Invalid file') } }
+    reader.readAsText(file)
+  }
+
+  return (
+    <div className="container" style={{maxWidth:900, margin:'0 auto'}}>
+      <h1 className="h1">Vitals</h1>
+
+      <div className="card">
+        <div className="row">
+          <label><input type="radio" name="t" value="bp" checked={type==='bp'} onChange={e=>setType(e.target.value)} /> BP</label>
+          <label><input type="radio" name="t" value="temp" checked={type==='temp'} onChange={e=>setType(e.target.value)} /> Temp</label>
+          <label><input type="radio" name="t" value="glu" checked={type==='glu'} onChange={e=>setType(e.target.value)} /> Glucose</label>
+        </div>
+
+        {type==='bp' && (
+          <div className="row">
+            <div className="field"><label>SYS</label><input value={sys} onChange={e=>setSys(e.target.value)} inputMode="numeric" /></div>
+            <div className="field"><label>DIA</label><input value={dia} onChange={e=>setDia(e.target.value)} inputMode="numeric" /></div>
+            <div className="field"><label>Pulse</label><input value={pulse} onChange={e=>setPulse(e.target.value)} inputMode="numeric" /></div>
+          </div>
+        )}
+        {type==='temp' && <div className="field"><label>°C</label><input value={temp} onChange={e=>setTemp(e.target.value)} inputMode="decimal" /></div>}
+        {type==='glu'  && <div className="field"><label>mmol/L</label><input value={glu} onChange={e=>setGlu(e.target.value)} inputMode="decimal" /></div>}
+
+        <div className="field">
+          <label>Date & time</label>
+          <input type="datetime-local" value={ts} onChange={e=>setTs(e.target.value)} />
+        </div>
+
+        <div className="row">
+          <button className="btn btn-primary" onClick={add}>Save</button>
+          <button className="btn btn-outline" onClick={exportJSON}>Export JSON</button>
+          <button className="btn btn-outline" onClick={exportCSV}>Export CSV</button>
+          <label className="btn btn-outline">
+            Import JSON
+            <input type="file" accept="application/json" style={{display:'none'}} onChange={e=>e.target.files[0] && importJSON(e.target.files[0])} />
+          </label>
+        </div>
+      </div>
+
+      <h2 className="h2" style={{marginTop:16}}>Charts (last 20)</h2>
+      <div className="card"><Line data={bpData} /></div>
+      <div className="card" style={{marginTop:12}}><Line data={tempData} /></div>
+      <div className="card" style={{marginTop:12}}><Line data={gluData} /></div>
+
+      <h2 className="h2" style={{marginTop:16}}>Latest</h2>
+      <ul>
+        {last.map(x=>(
+          <li key={x.id} className="card" style={{marginTop:8, padding:'12px'}}>
+            <div className="row" style={{justifyContent:'space-between'}}>
+              <div>
+                {x.type==='bp' ? `BP ${x.sys}/${x.dia}${x.pulse?` (${x.pulse})`:''}` :
+                 x.type==='temp' ? `Temp ${x.temp} °C` :
+                 `Glucose ${x.glu} mmol/L`}
+                {' — '}{new Date(x.at).toLocaleString()}
+              </div>
+              <button className="btn btn-danger" onClick={()=>remove(x.id)}>Delete</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+


### PR DESCRIPTION
Adds /qr (QR card), /vitals (BP/Temp/Glucose with charts, import/export), /docs (local documents with share, import/export). Updates navigation. No backend; all data stored locally.

------
https://chatgpt.com/codex/tasks/task_e_68a9b4b581208323ab80dd596a24d1a2