### PR TITLE
Add qrcode.react dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,13 @@
       "name": "carebee",
       "version": "0.0.0",
       "dependencies": {
-        "chart.js": "^4.5.0",
-        "dexie": "^4.2.0",
+        "chart.js": "^4.4.0",
+        "dexie": "^4.0.0",
         "i18next": "^25.4.0",
-        "qrcode": "^1.5.4",
+        "qrcode": "^1.5.0",
+        "qrcode.react": "^3.1.0",
         "react": "^19.1.1",
-        "react-chartjs-2": "^5.3.0",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^19.1.1",
         "react-i18next": "^15.7.1",
         "react-router-dom": "^7.8.1"
@@ -2633,6 +2634,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dexie": "^4.0.0",
     "i18next": "^25.4.0",
     "qrcode": "^1.5.0",
+    "qrcode.react": "^3.1.0",
     "react": "^19.1.1",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- add qrcode.react to dependencies for QR code rendering in React

## Testing
- `npm ci --legacy-peer-deps`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: empty block statements, unused var)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bc15d91883239ed4c144926d622f