### PR TITLE
fix: align qrcode.react with React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "i18next": "^25.4.0",
         "papaparse": "^5.4.1",
         "qrcode": "^1.5.0",
-        "qrcode.react": "^3.1.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.1.1",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^19.1.1",
@@ -2644,12 +2644,12 @@
       }
     },
     "node_modules/qrcode.react": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
-      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "i18next": "^25.4.0",
     "papaparse": "^5.4.1",
     "qrcode": "^1.5.0",
-    "qrcode.react": "^3.1.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.1",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- bump qrcode.react to 4.2.0 to support React 19

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9c99a75ec8323ad8be7580f06803e