### PR TITLE
Ensure routing respects base path and load i18n early

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,9 @@
+import './i18n.js'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import './index.css'
-import './i18n.js'
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter basename={import.meta.env.BASE_URL}>


### PR DESCRIPTION
## Summary
- load i18n configuration before any React code
- verify router uses Vite base path and workflow copies index to 404

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: around assigned a value, empty block statements, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9e73db26c8323990ccb65935503ab