### PR TITLE
feat: add daily summary email and autosend

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,18 +1,39 @@
 import { Routes, Route, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { useEffect } from 'react'
 import LanguageSwitcher from './components/LanguageSwitcher.jsx'
 import Home from './pages/Home.jsx'
 import Sos from './pages/Sos.jsx'
 import Profile from './pages/Profile.jsx'
+import { sendSummary } from './lib/dailySummary.js'
 import Meds from './pages/Meds.jsx'
 import Visits from './pages/Visits.jsx'
 import QR from './pages/QR.jsx'
 import Vitals from './pages/Vitals.jsx'
 import Docs from './pages/Docs.jsx'
 import Nearby from './pages/Nearby.jsx'
-export default function App() {
+
+export default function App () {
   const { t } = useTranslation()
   const year = new Date().getFullYear()
+
+  useEffect(() => {
+    try {
+      const p = JSON.parse(localStorage.getItem('carebee.profile') || '{}')
+      if (p.autosendEnabled) {
+        const now = new Date()
+        const hhmm = now.toTimeString().slice(0, 5)
+        const today = now.toISOString().slice(0, 10)
+        const last = localStorage.getItem('carebee.lastDailySent')
+        if (hhmm >= (p.autosendTime || '00:00') && last !== today) {
+          if (confirm('Send daily summary now?')) sendSummary()
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
   return (
     <>
       <header>

--- a/src/lib/dailySummary.js
+++ b/src/lib/dailySummary.js
@@ -1,0 +1,55 @@
+const PROFILE_KEY = 'carebee.profile'
+const LAST_KEY = 'carebee.lastDailySent'
+
+const load = (k, def) => {
+  try {
+    const v = localStorage.getItem(k)
+    return v ? JSON.parse(v) : def
+  } catch {
+    return def
+  }
+}
+
+const loadProfile = () => load(PROFILE_KEY, {})
+
+export function buildDailySummary () {
+  const today = new Date().toISOString().slice(0, 10)
+  const visits = load('carebee.visits', []).filter(v => v.date === today)
+  const medsRaw = load('carebee.meds', [])
+  const meds = []
+  medsRaw.forEach(m => {
+    if (m.mode === 'once') {
+      if (m.once.date === today) meds.push(`${m.once.time} ${m.name}`)
+    } else {
+      const d = m.daily
+      const within = (!d.start || today >= d.start) && (!d.end || today <= d.end)
+      if (within) d.times.forEach(t => meds.push(`${t} ${m.name}`))
+    }
+  })
+  const lines = [`Date: ${today}`]
+  lines.push('')
+  lines.push('Meds:')
+  if (meds.length) meds.forEach(m => lines.push(`- ${m}`))
+  else lines.push('- none')
+  lines.push('')
+  lines.push('Visits:')
+  if (visits.length) {
+    visits.forEach(v => {
+      const place = v.place ? ` @ ${v.place}` : ''
+      const notes = v.notes ? ` (${v.notes})` : ''
+      lines.push(`- ${v.time} ${v.doctor}${place}${notes}`)
+    })
+  } else lines.push('- none')
+  return lines.join('\n')
+}
+
+export function sendSummary () {
+  const profile = loadProfile()
+  const body = encodeURIComponent(buildDailySummary())
+  const to = encodeURIComponent(profile.recipients || '')
+  const subj = encodeURIComponent('CareBee Daily Summary')
+  const url = `mailto:${to}?subject=${subj}&body=${body}`
+  window.open(url)
+  try { localStorage.setItem(LAST_KEY, new Date().toISOString().slice(0, 10)) } catch { /* ignore */ }
+}
+

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,53 +1,93 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import QrCard from '../components/QrCard'
+import { buildDailySummary, sendSummary } from '../lib/dailySummary.js'
 
 const KEY = 'carebee.profile'
 const load = () => { try { const v = localStorage.getItem(KEY); return v ? JSON.parse(v) : {} } catch { return {} } }
 const save = (obj) => { try { localStorage.setItem(KEY, JSON.stringify(obj)) } catch { /* ignore */ } }
 
-export default function Profile() {
+export default function Profile () {
   const { t } = useTranslation()
-  const [p, setP] = useState(() => ({ firstName:'', lastName:'', age:'', phone:'', ...load() }))
+  const [p, setP] = useState(() => ({
+    firstName: '',
+    lastName: '',
+    age: '',
+    phone: '',
+    recipients: '',
+    autosendEnabled: false,
+    autosendTime: '08:00',
+    ...load()
+  }))
   const [msg, setMsg] = useState('')
 
-  useEffect(()=>{ save(p) }, [p])
+  useEffect(() => { save(p) }, [p])
 
   const onChange = (e) => {
-    const { name, value } = e.target
-    setP(prev => ({ ...prev, [name]: value }))
+    const { name, value, type, checked } = e.target
+    setP(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }))
   }
 
   const onSave = (e) => {
     e.preventDefault()
-    save(p); setMsg(t('profile.saved','Saved')); setTimeout(()=>setMsg(''), 2000)
+    save(p); setMsg(t('profile.saved', 'Saved')); setTimeout(() => setMsg(''), 2000)
+  }
+
+  const copySummary = () => {
+    navigator.clipboard?.writeText(buildDailySummary())
+    setMsg(t('profile.copied', 'Copied'))
+    setTimeout(() => setMsg(''), 2000)
+  }
+
+  const shareSummary = () => {
+    navigator.share({ title: 'CareBee Daily Summary', text: buildDailySummary() })
   }
 
   return (
     <>
-      <form onSubmit={onSave} className="sos-form" style={{maxWidth:520}}>
-        <h1>{t('profile.title','Patient profile')}</h1>
+      <form onSubmit={onSave} className="sos-form" style={{ maxWidth: 520 }}>
+        <h1>{t('profile.title', 'Patient profile')}</h1>
 
-        <label>{t('profile.firstName','First name')}
+        <label>{t('profile.firstName', 'First name')}
           <input name="firstName" value={p.firstName} onChange={onChange} required />
         </label>
 
-        <label>{t('profile.lastName','Last name')}
+        <label>{t('profile.lastName', 'Last name')}
           <input name="lastName" value={p.lastName} onChange={onChange} required />
         </label>
 
-        <label>{t('profile.age','Age')}
+        <label>{t('profile.age', 'Age')}
           <input name="age" type="number" min="0" max="130" value={p.age} onChange={onChange} />
         </label>
 
-        <label>{t('profile.phone','Phone')}
+        <label>{t('profile.phone', 'Phone')}
           <input name="phone" value={p.phone} onChange={onChange} placeholder="+33..." />
         </label>
 
-        <button type="submit">{t('save','Save')}</button>
-        {msg && <small aria-live="polite" style={{marginTop:6, display:'block'}}>{msg}</small>}
+        <label>{t('profile.recipients', 'Recipients')}
+          <input name="recipients" value={p.recipients} onChange={onChange} placeholder="alice@example.com,bob@example.com" />
+        </label>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input type="checkbox" name="autosendEnabled" checked={p.autosendEnabled} onChange={onChange} />
+          {t('profile.autosendEnabled', 'Enable auto send')}
+        </label>
+
+        <label>{t('profile.autosendTime', 'Autosend time')}
+          <input type="time" name="autosendTime" value={p.autosendTime} onChange={onChange} />
+        </label>
+
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 8 }}>
+          <button type="button" onClick={() => sendSummary()}>{t('profile.sendNow', 'Send summary now')}</button>
+          <button type="button" onClick={copySummary}>{t('profile.copy', 'Copy summary')}</button>
+          {navigator.share && <button type="button" onClick={shareSummary}>{t('profile.share', 'Share')}</button>}
+        </div>
+
+        <button type="submit" style={{ marginTop: 12 }}>{t('save', 'Save')}</button>
+        {msg && <small aria-live="polite" style={{ marginTop: 6, display: 'block' }}>{msg}</small>}
       </form>
       <QrCard />
     </>
   )
 }
+


### PR DESCRIPTION
## Summary
- allow configuring summary recipients and automatic daily send time
- implement summary builder using stored visits and meds and send/copy/share actions
- check autosend settings on app start and prompt to dispatch daily summary

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 5 errors)*
- `npx eslint src/pages/Profile.jsx src/App.jsx src/lib/dailySummary.js`

------
https://chatgpt.com/codex/tasks/task_e_68a9ec5f39188323a68342e18ff27168