### PR TITLE
feat: expand medication scheduling

### DIFF
--- a/src/pages/Meds.jsx
+++ b/src/pages/Meds.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const STORAGE = 'carebee.meds'
+const SLOT_DEFAULTS = { morning: '08:00', noon: '13:00', evening: '20:00' }
 
 const load = (k, def) => {
   try {
@@ -26,48 +27,73 @@ export default function Meds () {
   const { t } = useTranslation()
   const [items, setItems] = useState(() => load(STORAGE, []))
 
+  const today = () => new Date().toISOString().slice(0, 10)
+  const emptySlots = { morning: '', noon: '', evening: '' }
+
+  const [editId, setEditId] = useState(null)
   const [name, setName] = useState('')
   const [mode, setMode] = useState('once')
-  const today = () => new Date().toISOString().slice(0, 10)
-  const [onceDate, setOnceDate] = useState(today())
+  const [startDate, setStartDate] = useState(today())
+  const [endDate, setEndDate] = useState('')
   const [onceTime, setOnceTime] = useState('08:00')
-  const [start, setStart] = useState(today())
-  const [end, setEnd] = useState('')
-  const [duration, setDuration] = useState('')
-  const [times, setTimes] = useState('08:00')
+  const [slots, setSlots] = useState(emptySlots)
+  const [mealTiming, setMealTiming] = useState('after')
   const [days, setDays] = useState(7)
 
   useEffect(() => save(STORAGE, items), [items])
 
-  const add = () => {
-    if (!name.trim()) return
-    if (mode === 'once') {
-      setItems(p => [...p, { id: Date.now().toString(), name: name.trim(), mode, once: { date: onceDate, time: onceTime } }])
-    } else {
-      if (!start) return
-      if (!end && !duration) return
-      const timesArr = times.split(',').map(s => s.trim()).filter(Boolean)
-      if (!timesArr.length) return
-      let endDate = end
-      if (!endDate && duration) endDate = addDays(start, parseInt(duration) - 1)
-      setItems(p => [...p, { id: Date.now().toString(), name: name.trim(), mode, daily: { start, end: endDate, times: timesArr } }])
-    }
+  const reset = () => {
+    setEditId(null)
     setName('')
     setMode('once')
-    setOnceDate(today())
+    setStartDate(today())
+    setEndDate('')
     setOnceTime('08:00')
-    setStart(today())
-    setEnd('')
-    setDuration('')
-    setTimes('08:00')
+    setSlots(emptySlots)
+    setMealTiming('after')
+  }
+
+  const saveItem = () => {
+    if (!name.trim()) return
+    const base = {
+      id: editId || Date.now().toString(),
+      name: name.trim(),
+      mode,
+      startDate,
+      mealTiming
+    }
+    let item
+    if (mode === 'once') {
+      item = { ...base, onceTime }
+    } else {
+      if (!Object.values(slots).some(Boolean)) return
+      item = { ...base, endDate: endDate || undefined, slots }
+    }
+    setItems(p => editId ? p.map(i => i.id === editId ? item : i) : [...p, item])
+    reset()
+  }
+
+  const edit = m => {
+    setEditId(m.id)
+    setName(m.name)
+    setMode(m.mode)
+    setStartDate(m.startDate)
+    setEndDate(m.endDate || '')
+    setMealTiming(m.mealTiming || 'after')
+    if (m.mode === 'once') {
+      setOnceTime(m.onceTime)
+      setSlots(emptySlots)
+    } else {
+      setSlots({ ...emptySlots, ...m.slots })
+    }
   }
 
   const remove = id => setItems(p => p.filter(i => i.id !== id))
-  const extend = id => setItems(p => p.map(i => i.id === id ? { ...i, daily: { ...i.daily, end: addDays(i.daily.end || today(), 7) } } : i))
+  const extend = id => setItems(p => p.map(i => i.id === id ? { ...i, endDate: addDays(i.endDate || today(), 7) } : i))
 
   const renewals = useMemo(() => {
     const now = today()
-    return items.filter(i => i.mode === 'daily' && i.daily?.end && (new Date(i.daily.end) - new Date(now)) / 86400000 <= 3)
+    return items.filter(i => i.mode === 'daily' && i.endDate && (new Date(i.endDate) - new Date(now)) / 86400000 <= 3)
   }, [items])
 
   const schedule = useMemo(() => {
@@ -78,11 +104,10 @@ export default function Meds () {
       const entries = []
       items.forEach(m => {
         if (m.mode === 'once') {
-          if (m.once.date === date) entries.push(`${m.name} ${m.once.time}`)
+          if (m.startDate === date) entries.push(`${m.name} ${m.onceTime} ${m.mealTiming}`)
         } else {
-          const d = m.daily
-          const within = (!d.start || date >= d.start) && (!d.end || date <= d.end)
-          if (within) d.times.forEach(t => entries.push(`${m.name} ${t}`))
+          const within = (!m.startDate || date >= m.startDate) && (!m.endDate || date <= m.endDate)
+          if (within) Object.values(m.slots || {}).forEach(t => { if (t) entries.push(`${m.name} ${t} ${m.mealTiming}`) })
         }
       })
       list.push({ date, entries })
@@ -91,7 +116,7 @@ export default function Meds () {
   }, [items, days])
 
   const downloadICS = m => {
-    const dt = `${m.once.date.replace(/-/g, '')}T${m.once.time.replace(':', '')}00`
+    const dt = `${m.startDate.replace(/-/g, '')}T${m.onceTime.replace(':', '')}00`
     const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:${m.id}\nDTSTAMP:${dt}\nDTSTART:${dt}\nSUMMARY:${m.name}\nEND:VEVENT\nEND:VCALENDAR`
     const blob = new Blob([ics], { type: 'text/calendar' })
     const a = document.createElement('a')
@@ -101,6 +126,11 @@ export default function Meds () {
     URL.revokeObjectURL(a.href)
   }
 
+  const toggleSlot = s => e => {
+    const checked = e.target.checked
+    setSlots(p => ({ ...p, [s]: checked ? (p[s] || SLOT_DEFAULTS[s]) : '' }))
+  }
+
   return (
     <div className='container'>
       <h1>{t('meds.title', 'Meds')}</h1>
@@ -108,14 +138,14 @@ export default function Meds () {
       {renewals.map(r => (
         <div key={r.id} className='card'>
           <div className='row' style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <div>{t('meds.renew', 'Course ends')} {r.name} {t('meds.on', 'on')} {r.daily.end}</div>
+            <div>{t('meds.renew', 'Course ends')} {r.name} {t('meds.on', 'on')} {r.endDate}</div>
             <button className='btn btn-primary' onClick={() => extend(r.id)}>{t('meds.extend', 'Extend')}</button>
           </div>
         </div>
       ))}
 
       <div className='card'>
-        <h2>{t('meds.add', 'Add medicine')}</h2>
+        <h2>{t('meds.add', editId ? 'Edit medicine' : 'Add medicine')}</h2>
         <div className='field'>
           <label>{t('meds.name', 'Name')}
             <input value={name} onChange={e => setName(e.target.value)} />
@@ -125,39 +155,48 @@ export default function Meds () {
           <label><input type='radio' value='once' checked={mode === 'once'} onChange={e => setMode(e.target.value)} /> {t('meds.once', 'Once')}</label>
           <label><input type='radio' value='daily' checked={mode === 'daily'} onChange={e => setMode(e.target.value)} /> {t('meds.daily', 'Daily')}</label>
         </div>
+        <div className='row' style={{ display: 'flex', gap: 8 }}>
+          <label>{t('meds.start', 'Start')}
+            <input type='date' value={startDate} onChange={e => setStartDate(e.target.value)} />
+          </label>
+          {mode === 'daily' && (
+            <label>{t('meds.end', 'End')}
+              <input type='date' value={endDate} onChange={e => setEndDate(e.target.value)} />
+            </label>
+          )}
+        </div>
 
         {mode === 'once' ? (
-          <div className='row' style={{ display: 'flex', gap: 8 }}>
-            <label>{t('meds.date', 'Date')}
-              <input type='date' value={onceDate} onChange={e => setOnceDate(e.target.value)} />
-            </label>
+          <div className='field'>
             <label>{t('meds.time', 'Time')}
               <input type='time' value={onceTime} onChange={e => setOnceTime(e.target.value)} />
             </label>
           </div>
         ) : (
-          <>
-            <div className='row' style={{ display: 'flex', gap: 8 }}>
-              <label>{t('meds.start', 'Start')}
-                <input type='date' value={start} onChange={e => setStart(e.target.value)} />
+          <div className='field' style={{ display: 'flex', gap: 8 }}>
+            {['morning', 'noon', 'evening'].map(s => (
+              <label key={s} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <span>{t(`meds.${s}`, s)}</span>
+                <input type='checkbox' checked={!!slots[s]} onChange={toggleSlot(s)} />
+                {slots[s] && <input type='time' value={slots[s]} onChange={e => setSlots(p => ({ ...p, [s]: e.target.value }))} />}
               </label>
-              <label>{t('meds.end', 'End')}
-                <input type='date' value={end} onChange={e => setEnd(e.target.value)} />
-              </label>
-              <label>{t('meds.duration', 'Days')}
-                <input type='number' min='1' value={duration} onChange={e => setDuration(e.target.value)} />
-              </label>
-            </div>
-            <div className='field'>
-              <label>{t('meds.times', 'Times (comma separated)')}
-                <input value={times} onChange={e => setTimes(e.target.value)} />
-              </label>
-            </div>
-          </>
+            ))}
+          </div>
         )}
 
+        <div className='field'>
+          <label>{t('meds.meal', 'Meal')}
+            <select value={mealTiming} onChange={e => setMealTiming(e.target.value)}>
+              <option value='before'>{t('meds.before', 'Before food')}</option>
+              <option value='with'>{t('meds.with', 'With food')}</option>
+              <option value='after'>{t('meds.after', 'After food')}</option>
+            </select>
+          </label>
+        </div>
+
         <div className='row' style={{ display: 'flex', gap: 8 }}>
-          <button className='btn btn-primary' onClick={add}>{t('save', 'Save')}</button>
+          <button className='btn btn-primary' onClick={saveItem}>{t('save', 'Save')}</button>
+          {editId && <button className='btn btn-outline' onClick={reset}>{t('cancel', 'Cancel')}</button>}
         </div>
       </div>
 
@@ -189,11 +228,12 @@ export default function Meds () {
                 <strong>{m.name}</strong>
                 {' '}
                 {m.mode === 'once'
-                  ? `${m.once.date} ${m.once.time}`
-                  : `${m.daily.start}${m.daily.end ? '–' + m.daily.end : ''} ${m.daily.times.join(', ')}`}
+                  ? `${m.startDate} ${m.onceTime} ${m.mealTiming}`
+                  : `${m.startDate}${m.endDate ? '–' + m.endDate : ''} ${Object.values(m.slots || {}).filter(Boolean).join(', ')} ${m.mealTiming}`}
               </div>
               <div className='row' style={{ display: 'flex', gap: 8 }}>
                 {m.mode === 'once' && <button className='btn btn-outline' onClick={() => downloadICS(m)}>ICS</button>}
+                <button className='btn btn-outline' onClick={() => edit(m)}>{t('edit', 'Edit')}</button>
                 <button className='btn btn-danger' onClick={() => remove(m.id)}>{t('delete', 'Delete')}</button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- extend medication model with start/end dates, meal timing, and morning/noon/evening slots
- add edit support and toggleable slot times with defaults
- regenerate daily schedule based on date range and selected slots

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: no-unused-vars, no-empty)


------
https://chatgpt.com/codex/tasks/task_e_68a9ec60d75883238f213905c601a177