### PR TITLE
refactor: tidy geo util and cleanup catch blocks

### DIFF
--- a/src/lib/geo.js
+++ b/src/lib/geo.js
@@ -24,8 +24,8 @@ async function overpassFetch(body){
 }
 
 export async function overpassAround(lat, lon, radiusKm, qlBlocks){
-  const around = Math.round(radiusKm * 1000)
-  const any = qlBlocks.map(q => `nwr(around:${around},${lat},${lon})${q};`).join("\n")
+  const radiusM = Math.round(radiusKm * 1000)
+  const any = qlBlocks.map(q => `nwr(around:${radiusM},${lat},${lon})${q};`).join("\n")
   const body = `[out:json][timeout:25];(${any});out center tags;`
   const data = await overpassFetch(body)
   return (data.elements||[]).map(el=>{

--- a/src/pages/Docs.jsx
+++ b/src/pages/Docs.jsx
@@ -60,7 +60,7 @@ export default function Docs(){
         await addFileRec(new File([blob], f.name, { type: f.type }), f)
       }
       refresh()
-    }catch(e){ void e; alert('Invalid file') } }
+    }catch{ alert('Invalid file') } }
     r.readAsText(file)
   }
 
@@ -72,7 +72,7 @@ export default function Docs(){
       }else{
         open(f)
       }
-      }catch(e){ /* ignore */ void e; }
+      }catch(e){ console.error(e) }
   }
 
   return (

--- a/src/pages/QR.jsx
+++ b/src/pages/QR.jsx
@@ -3,9 +3,9 @@ import { useTranslation } from 'react-i18next'
 import QRCode from 'qrcode'
 
 const KEY = 'carebee.qr'
-const load = () => { try { const v=localStorage.getItem(KEY); return v?JSON.parse(v):{} } catch (e) { void e; return {} } }
-const save = (o) => { try { localStorage.setItem(KEY, JSON.stringify(o)) } catch (e) { /* ignore */ void e; } }
-const loadProfile = () => { try { const v=localStorage.getItem('carebee.profile'); return v?JSON.parse(v):{} } catch (e) { void e; return {} } }
+const load = () => { try { const v=localStorage.getItem(KEY); return v?JSON.parse(v):{} } catch { return {} } }
+const save = (o) => { try { localStorage.setItem(KEY, JSON.stringify(o)) } catch (e) { console.error(e) } }
+const loadProfile = () => { try { const v=localStorage.getItem('carebee.profile'); return v?JSON.parse(v):{} } catch { return {} } }
 
 export default function QR(){
   const { t } = useTranslation()

--- a/src/pages/Vitals.jsx
+++ b/src/pages/Vitals.jsx
@@ -5,8 +5,8 @@ import { useTranslation } from 'react-i18next'
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend)
 
 const KEY='carebee.vitals'
-const load=()=>{try{const v=localStorage.getItem(KEY);return v?JSON.parse(v):[]}catch(e){void e;return[]}}
-const save=(arr)=>{try{localStorage.setItem(KEY,JSON.stringify(arr))}catch(e){/* ignore */ void e;}}
+const load=()=>{try{const v=localStorage.getItem(KEY);return v?JSON.parse(v):[]}catch{return[]}}
+const save=(arr)=>{try{localStorage.setItem(KEY,JSON.stringify(arr))}catch(e){console.error(e)}}
 const nowISO = ()=> new Date().toISOString()
 
 export default function Vitals(){
@@ -54,7 +54,7 @@ export default function Vitals(){
       const reader=new FileReader()
       reader.onload=()=>{ try{
         const arr=JSON.parse(reader.result); if(!Array.isArray(arr)) throw new Error();
-        setList(arr); }catch(e){ void e; alert('Invalid file') } }
+        setList(arr); }catch{ alert('Invalid file') } }
       reader.readAsText(file)
     }
 


### PR DESCRIPTION
## Summary
- simplify overpass radius calculation
- replace empty catch blocks in Docs, QR and Vitals pages with meaningful handling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa058654d88323b0aff9b04d349a49