### PR TITLE
refactor: remove autosend settings

### DIFF
--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,11 +1,26 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import QrCard from '../components/QrCard'
-import { buildDailySummary, sendSummary } from '../lib/dailySummary.js'
 
 const KEY = 'carebee.profile'
-const load = () => { try { const v = localStorage.getItem(KEY); return v ? JSON.parse(v) : {} } catch { return {} } }
-const save = (obj) => { try { localStorage.setItem(KEY, JSON.stringify(obj)) } catch { /* ignore */ } }
+const load = () => {
+  try {
+    const v = localStorage.getItem(KEY)
+    if (!v) return {}
+    const { autosendEnabled: _ae, autosendTime: _at, ...rest } = JSON.parse(v)
+    return rest
+  } catch {
+    return {}
+  }
+}
+const save = (obj) => {
+  try {
+    const { autosendEnabled: _ae, autosendTime: _at, ...rest } = obj
+    localStorage.setItem(KEY, JSON.stringify(rest))
+  } catch {
+    /* ignore */
+  }
+}
 
 export default function Profile () {
   const { t } = useTranslation()
@@ -15,8 +30,6 @@ export default function Profile () {
     age: '',
     phone: '',
     recipients: '',
-    autosendEnabled: false,
-    autosendTime: '08:00',
     ...load()
   }))
   const [msg, setMsg] = useState('')
@@ -31,16 +44,6 @@ export default function Profile () {
   const onSave = (e) => {
     e.preventDefault()
     save(p); setMsg(t('profile.saved', 'Saved')); setTimeout(() => setMsg(''), 2000)
-  }
-
-  const copySummary = () => {
-    navigator.clipboard?.writeText(buildDailySummary())
-    setMsg(t('profile.copied', 'Copied'))
-    setTimeout(() => setMsg(''), 2000)
-  }
-
-  const shareSummary = () => {
-    navigator.share({ title: 'CareBee Daily Summary', text: buildDailySummary() })
   }
 
   return (
@@ -67,21 +70,6 @@ export default function Profile () {
         <label>{t('profile.recipients', 'Recipients')}
           <input name="recipients" value={p.recipients} onChange={onChange} placeholder="alice@example.com,bob@example.com" />
         </label>
-
-        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <input type="checkbox" name="autosendEnabled" checked={p.autosendEnabled} onChange={onChange} />
-          {t('profile.autosendEnabled', 'Enable auto send')}
-        </label>
-
-        <label>{t('profile.autosendTime', 'Autosend time')}
-          <input type="time" name="autosendTime" value={p.autosendTime} onChange={onChange} />
-        </label>
-
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 8 }}>
-          <button type="button" onClick={() => sendSummary()}>{t('profile.sendNow', 'Send summary now')}</button>
-          <button type="button" onClick={copySummary}>{t('profile.copy', 'Copy summary')}</button>
-          {navigator.share && <button type="button" onClick={shareSummary}>{t('profile.share', 'Share')}</button>}
-        </div>
 
         <button type="submit" style={{ marginTop: 12 }}>{t('save', 'Save')}</button>
         {msg && <small aria-live="polite" style={{ marginTop: 6, display: 'block' }}>{msg}</small>}


### PR DESCRIPTION
## Summary
- remove autosend configuration and manual summary buttons from profile
- strip autosend fields from localStorage persistence

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa0a87ae088323950b89bdc0450e43