### PR TITLE
Refactor autosend summary to reusable helpers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,9 @@
 import { Routes, Route, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { useEffect } from 'react'
 import LanguageSwitcher from './components/LanguageSwitcher.jsx'
 import Home from './pages/Home.jsx'
 import Sos from './pages/Sos.jsx'
 import Profile from './pages/Profile.jsx'
-import { sendSummary } from './lib/dailySummary.js'
 import Meds from './pages/Meds.jsx'
 import Visits from './pages/Visits.jsx'
 import Calendar from './pages/Calendar.jsx'
@@ -18,22 +16,6 @@ export default function App () {
   const { t } = useTranslation()
   const year = new Date().getFullYear()
 
-  useEffect(() => {
-    try {
-      const p = JSON.parse(localStorage.getItem('carebee.profile') || '{}')
-      if (p.autosendEnabled) {
-        const now = new Date()
-        const hhmm = now.toTimeString().slice(0, 5)
-        const today = now.toISOString().slice(0, 10)
-        const last = localStorage.getItem('carebee.lastDailySent')
-        if (hhmm >= (p.autosendTime || '00:00') && last !== today) {
-          if (confirm('Send daily summary now?')) sendSummary()
-        }
-      }
-    } catch {
-      /* ignore */
-    }
-  }, [])
 
   return (
     <>

--- a/src/lib/dailySummary.js
+++ b/src/lib/dailySummary.js
@@ -12,6 +12,20 @@ const load = (k, def) => {
 
 const loadProfile = () => load(PROFILE_KEY, {})
 
+export function shouldAutoSend () {
+  try {
+    const p = loadProfile()
+    if (!p.autosendEnabled) return false
+    const now = new Date()
+    const hhmm = now.toTimeString().slice(0, 5)
+    const today = now.toISOString().slice(0, 10)
+    const last = localStorage.getItem(LAST_KEY)
+    return hhmm >= (p.autosendTime || '00:00') && last !== today
+  } catch {
+    return false
+  }
+}
+
 export function buildDailySummary () {
   const today = new Date().toISOString().slice(0, 10)
   const visits = load('carebee.visits', []).filter(v => v.date === today)
@@ -51,5 +65,9 @@ export function sendSummary () {
   const url = `mailto:${to}?subject=${subj}&body=${body}`
   window.open(url)
   try { localStorage.setItem(LAST_KEY, new Date().toISOString().slice(0, 10)) } catch { /* ignore */ }
+}
+
+export function maybeSendDailySummary () {
+  if (shouldAutoSend() && confirm('Send daily summary now?')) sendSummary()
 }
 

--- a/src/pages/Vitals.jsx
+++ b/src/pages/Vitals.jsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useEffect } from 'react'
 import { Line } from 'react-chartjs-2'
 import { CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend, Chart as ChartJS } from 'chart.js'
 import { useTranslation } from 'react-i18next'
+import { maybeSendDailySummary } from '../lib/dailySummary.js'
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend)
 
 const KEY='carebee.vitals'
@@ -17,6 +18,7 @@ export default function Vitals(){
   const [temp,setTemp]=useState(''); const [glu,setGlu]=useState(''); const [ts,setTs]=useState(()=>nowISO().slice(0,16))
 
   useEffect(()=>save(list),[list])
+  useEffect(()=>{ maybeSendDailySummary() },[])
 
   const add=()=>{
     const time = ts ? new Date(ts) : new Date()


### PR DESCRIPTION
## Summary
- remove app-level autosend effect in App.jsx
- add daily summary helpers to detect and trigger autosend
- invoke autosend helper on Vitals page mount

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa0a87e4288323b029300a7874e98f