### PR TITLE
feat: improve meds calendar export

### DIFF
--- a/src/pages/Meds.jsx
+++ b/src/pages/Meds.jsx
@@ -23,6 +23,18 @@ const addDays = (d, n) => {
   return x.toISOString().slice(0, 10)
 }
 
+function toICSDateTime (isoDate, hhmm) {
+  const [h, m] = (hhmm || '09:00').split(':')
+  const dt = new Date(`${isoDate}T${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:00`)
+  const y = dt.getFullYear()
+  const mo = String(dt.getMonth() + 1).padStart(2, '0')
+  const d = String(dt.getDate()).padStart(2, '0')
+  const H = String(dt.getHours()).padStart(2, '0')
+  const M = String(dt.getMinutes()).padStart(2, '0')
+  const S = String(dt.getSeconds()).padStart(2, '0')
+  return `${y}${mo}${d}T${H}${M}${S}`
+}
+
 export default function Meds () {
   const { t } = useTranslation()
   const [items, setItems] = useState(() => load(STORAGE, []))
@@ -116,9 +128,46 @@ export default function Meds () {
   }, [items, days])
 
   const downloadICS = m => {
-    const dt = `${m.startDate.replace(/-/g, '')}T${m.onceTime.replace(':', '')}00`
-    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:${m.id}\nDTSTAMP:${dt}\nDTSTART:${dt}\nSUMMARY:${m.name}\nEND:VEVENT\nEND:VCALENDAR`
-    const blob = new Blob([ics], { type: 'text/calendar' })
+    const uidBase = `${m.id}@carebee`
+    const now = toICSDateTime(today(), new Date().toTimeString().slice(0, 5))
+    const summary = `${m.name} — ${t('meds.meal_' + m.mealTiming)}`
+
+    const formatEvent = (date, time, uid, rrule) => {
+      const startDate = new Date(`${date}T${time}:00`)
+      const end = new Date(startDate.getTime() + 30 * 60000)
+      const dtstart = toICSDateTime(date, time)
+      const dtend = toICSDateTime(
+        end.toISOString().slice(0, 10),
+        `${String(end.getHours()).padStart(2, '0')}:${String(end.getMinutes()).padStart(2, '0')}`
+      )
+      return [
+        'BEGIN:VEVENT',
+        `UID:${uid}`,
+        `DTSTAMP:${now}`,
+        `DTSTART:${dtstart}`,
+        `DTEND:${dtend}`,
+        `SUMMARY:${summary}`,
+        rrule,
+        'END:VEVENT'
+      ]
+        .filter(Boolean)
+        .join('\r\n')
+    }
+
+    let events = []
+    if (m.mode === 'once') {
+      events.push(formatEvent(m.startDate, m.onceTime, uidBase, ''))
+    } else {
+      Object.entries(m.slots || {}).forEach(([slot, time]) => {
+        if (!time) return
+        const uid = `${m.id}-${slot}@carebee`
+        const rrule = `RRULE:FREQ=DAILY${m.endDate ? `;UNTIL=${toICSDateTime(m.endDate, time)}` : ''}`
+        events.push(formatEvent(m.startDate, time, uid, rrule))
+      })
+    }
+
+    const ics = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//CareBee//EN', ...events, 'END:VCALENDAR'].join('\r\n')
+    const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' })
     const a = document.createElement('a')
     a.href = URL.createObjectURL(blob)
     a.download = `${m.name}.ics`
@@ -232,7 +281,7 @@ export default function Meds () {
                   : `${m.startDate}${m.endDate ? '–' + m.endDate : ''} ${Object.values(m.slots || {}).filter(Boolean).join(', ')} ${m.mealTiming}`}
               </div>
               <div className='row' style={{ display: 'flex', gap: 8 }}>
-                {m.mode === 'once' && <button className='btn btn-outline' onClick={() => downloadICS(m)}>ICS</button>}
+                <button className='btn btn-outline' onClick={() => downloadICS(m)}>{t('meds.addToCalendar', 'Add to calendar')}</button>
                 <button className='btn btn-outline' onClick={() => edit(m)}>{t('edit', 'Edit')}</button>
                 <button className='btn btn-danger' onClick={() => remove(m.id)}>{t('delete', 'Delete')}</button>
               </div>


### PR DESCRIPTION
## Summary
- enhance meds calendar export with stable UID and formatted start/end times
- generate recurring events and summary with meal context
- show "Add to calendar" button for all medicines

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa0a963d148323972da8b77260f4b5