### PR TITLE
Highlight current day in calendar view

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -44,3 +44,10 @@ form { display: flex; flex-direction: column; gap: 1rem; }
 .sos-form { max-width: 400px; margin: 0 auto; }
 label { display: flex; flex-direction: column; font-weight: 500; gap: 0.25rem; }
 input, textarea { padding: 0.5rem; font-size: 1rem; border: 1px solid var(--black); border-radius: 4px; }
+
+.today-highlight {
+  background: var(--yellow);
+  color: var(--black);
+  padding: 0 4px;
+  border-radius: 4px;
+}

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -104,7 +104,9 @@ export default function Calendar () {
         const list = eventsByDate[d]
         return (
           <div key={d} className='card' style={{ marginBottom: 12 }}>
-            <strong>{d}</strong>
+            <strong className={d === today ? 'today-highlight' : ''}>
+              {d === today ? t('today', 'Today') : d}
+            </strong>
             {list.length ? (
               <ul>
                 {list.map((e, i) => (


### PR DESCRIPTION
## Summary
- mark current calendar day with a translated label and highlight style
- add today-highlight CSS class for visual emphasis

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa0aaf5f0483239de02fedf3d878d6