### PR TITLE
Translate QR payload labels and update memo dependency

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,7 +45,15 @@
     "includeICE": "Include ICE",
     "generate": "Generate QR",
     "download": "Download PNG",
-    "print": "Print"
+    "print": "Print",
+    "payload": {
+      "name": "Name",
+      "age": "Age",
+      "allergies": "Allergies",
+      "meds": "Meds",
+      "ice": "ICE",
+      "notes": "Notes"
+    }
   },
   "meds": {
     "title": "Medicine schedule",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -45,7 +45,15 @@
     "includeICE": "Inclure ICE",
     "generate": "Générer QR",
     "download": "Télécharger PNG",
-    "print": "Imprimer"
+    "print": "Imprimer",
+    "payload": {
+      "name": "Nom",
+      "age": "Âge",
+      "allergies": "Allergies",
+      "meds": "Médicaments",
+      "ice": "ICE",
+      "notes": "Notes"
+    }
   },
   "meds": {
     "title": "Prise des médicaments",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -45,7 +45,15 @@
     "includeICE": "Указать ICE",
     "generate": "Сгенерировать QR",
     "download": "Скачать PNG",
-    "print": "Печать"
+    "print": "Печать",
+    "payload": {
+      "name": "Имя",
+      "age": "Возраст",
+      "allergies": "Аллергии",
+      "meds": "Препараты",
+      "ice": "ICE",
+      "notes": "Заметки"
+    }
   },
   "meds": {
     "title": "График приёма лекарств",

--- a/src/pages/QR.jsx
+++ b/src/pages/QR.jsx
@@ -8,7 +8,7 @@ const save = (o) => { try { localStorage.setItem(KEY, JSON.stringify(o)) } catch
 const loadProfile = () => { try { const v=localStorage.getItem('carebee.profile'); return v?JSON.parse(v):{} } catch (e) { void e; return {} } }
 
 export default function QR(){
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const prof = loadProfile()
   const [form, setForm] = useState(() => ({
     allergies:'', conditions:'', meds:'', iceName:'', icePhone:'',
@@ -20,16 +20,17 @@ export default function QR(){
   useEffect(()=>save(form),[form])
 
   const payload = useMemo(()=>{
+    void i18n.language
     const lines = []
     const name = [prof.firstName, prof.lastName].filter(Boolean).join(' ')
-    if (name) lines.push(`Name: ${name}`)
-    if (form.includeAge && prof.age) lines.push(`Age: ${prof.age}`)
-    if (form.includeAllergies && form.allergies) lines.push(`Allergies: ${form.allergies}`)
-    if (form.includeMeds && form.meds) lines.push(`Meds: ${form.meds}`)
-    if (form.includeICE && (form.iceName || form.icePhone)) lines.push(`ICE: ${form.iceName || ''} ${form.icePhone || ''}`.trim())
-    if (form.conditions) lines.push(`Notes: ${form.conditions}`)
+    if (name) lines.push(`${t('qr.payload.name')}: ${name}`)
+    if (form.includeAge && prof.age) lines.push(`${t('qr.payload.age')}: ${prof.age}`)
+    if (form.includeAllergies && form.allergies) lines.push(`${t('qr.payload.allergies')}: ${form.allergies}`)
+    if (form.includeMeds && form.meds) lines.push(`${t('qr.payload.meds')}: ${form.meds}`)
+    if (form.includeICE && (form.iceName || form.icePhone)) lines.push(`${t('qr.payload.ice')}: ${form.iceName || ''} ${form.icePhone || ''}`.trim())
+    if (form.conditions) lines.push(`${t('qr.payload.notes')}: ${form.conditions}`)
     return lines.join('\n').slice(0, 600)
-  }, [form, prof])
+  }, [form, prof, t, i18n.language])
 
   const generate = async () => {
     const url = await QRCode.toDataURL(payload, { width: 512, margin: 1 })


### PR DESCRIPTION
## Summary
- localize QR payload labels and use i18n translations
- regenerate QR payload on language change by tracking translator
- add translations for new payload labels in all locale files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ab981f48323af0a365243181614