### PR TITLE
Use kilometers for nearby search radius labels

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -111,7 +111,7 @@
     "useMyLocation": "Use my location",
     "searchAddress": "Search address",
     "addressPlaceholder": "Street, city…",
-    "radius": "Radius (m)",
+    "radius": "Radius",
     "tabPharmacies": "Pharmacies",
     "tabSpecialists": "Specialists & services",
     "load": "Load",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -111,7 +111,7 @@
     "useMyLocation": "Utiliser ma position",
     "searchAddress": "Rechercher une adresse",
     "addressPlaceholder": "Rue, ville…",
-    "radius": "Rayon (m)",
+    "radius": "Rayon",
     "tabPharmacies": "Pharmacies",
     "tabSpecialists": "Spécialistes & services",
     "load": "Charger",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -103,7 +103,7 @@
     "useMyLocation": "Определить местоположение",
     "searchAddress": "Поиск адреса",
     "addressPlaceholder": "Улица, город…",
-    "radius": "Радиус (м)",
+    "radius": "Радиус",
     "tabPharmacies": "Аптеки",
     "tabSpecialists": "Специалисты и сервисы",
     "load": "Загрузить",


### PR DESCRIPTION
## Summary
- change `nearby.radius` in English, Russian, and French locales from meter-based text to unit-neutral labels
- rely on Nearby page to append `(km)`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ad196a4832398a68f3cb7be467e