### PR TITLE
Handle Overpass timeout with localized errors

### DIFF
--- a/src/lib/geo.js
+++ b/src/lib/geo.js
@@ -12,15 +12,20 @@ const OVERPASS = [
 ]
 
 async function overpassFetch(body){
-  let lastErr
   for (const url of OVERPASS){
+    const controller = new AbortController()
+    const timer = setTimeout(()=>controller.abort(), 25000)
     try{
-      const r = await fetch(url, { method:"POST", headers:{ "Content-Type":"text/plain" }, body })
-      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      const r = await fetch(url, { method:"POST", headers:{ "Content-Type":"text/plain" }, body, signal: controller.signal })
+      if (!r.ok) throw new Error('overpass_failed')
       return await r.json()
-    }catch(e){ lastErr = e }
+    }catch{
+      // try next endpoint on failure/timeout
+    }finally{
+      clearTimeout(timer)
+    }
   }
-  throw lastErr
+  throw new Error('overpass_failed')
 }
 
 export async function overpassAround(lat, lon, radiusKm, qlBlocks){

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -127,6 +127,7 @@
     "website": "Website",
     "geolocDenied": "Location denied — enter an address.",
     "geocodingError": "Address not found.",
+    "overpassError": "Unable to reach Overpass. Please try again later.",
     "source": "Data source: OpenStreetMap (Overpass).",
     "importFiness": "Import FINESS CSV",
     "finessHint": "Load official CSV to search registered facilities.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -127,6 +127,7 @@
     "website": "Site web",
     "geolocDenied": "Position refusée — saisissez une adresse.",
     "geocodingError": "Adresse introuvable.",
+    "overpassError": "Impossible de joindre Overpass. Veuillez réessayer plus tard.",
     "source": "Source : OpenStreetMap (Overpass).",
     "importFiness": "Importer FINESS CSV",
     "finessHint": "Chargez le CSV officiel pour chercher les établissements enregistrés.",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -119,6 +119,7 @@
     "website": "Сайт",
     "geolocDenied": "Доступ к местоположению запрещён — введите адрес.",
     "geocodingError": "Адрес не найден.",
+    "overpassError": "Не удаётся связаться с Overpass. Попробуйте позже.",
     "source": "Источник данных: OpenStreetMap (Overpass).",
     "importFiness": "Импорт FINESS CSV",
     "finessHint": "Загрузите официальный CSV для поиска учреждений.",

--- a/src/pages/Nearby.jsx
+++ b/src/pages/Nearby.jsx
@@ -51,7 +51,11 @@ export default function Nearby(){
       }).sort((a,b)=>(a.distKm ?? 1e9) - (b.distKm ?? 1e9))
       setItems(enriched)
     }catch(e){
-      setErr(e.message==='not_found' ? t('nearby.geocodingError') : e.message)
+      let msg
+      if (e.message==='not_found') msg = t('nearby.geocodingError')
+      else if (e.message==='overpass_failed') msg = t('nearby.overpassError')
+      else msg = e.message
+      setErr(msg)
       setItems([])
     }finally{
       setLoading(false)


### PR DESCRIPTION
## Summary
- Add AbortController timeout and custom `overpass_failed` error for Overpass requests
- Display friendly translated message when Overpass API is unreachable
- Provide `nearby.overpassError` strings in English, Russian, and French

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `node --input-type=module <<'NODE' ...`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ad276288323bf1a80212e1b1016