### PR TITLE
feat: show one decimal in pharmacy distances

### DIFF
--- a/src/pages/Nearby.jsx
+++ b/src/pages/Nearby.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { haversineKm, overpassAround, geocodeAddress, fetchNearbyPharmacies } from '../lib/geo'
 
-const KM = m => (m/1000).toFixed(2)
+const KM = m => (m/1000).toFixed(1)
 
 export default function Nearby(){
   const { t, i18n } = useTranslation()


### PR DESCRIPTION
## Summary
- show distance with one decimal precision in the Nearby screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ad1b5e48323b5f3ea432f07fa7d