### PR TITLE
Use structured objects for med schedule entries

### DIFF
--- a/src/pages/Meds.jsx
+++ b/src/pages/Meds.jsx
@@ -104,10 +104,12 @@ export default function Meds () {
       const entries = []
       items.forEach(m => {
         if (m.mode === 'once') {
-          if (m.startDate === date) entries.push(`${m.name} ${m.onceTime} ${m.mealTiming}`)
+          if (m.startDate === date) entries.push({ name: m.name, time: m.onceTime, meal: m.mealTiming })
         } else {
           const within = (!m.startDate || date >= m.startDate) && (!m.endDate || date <= m.endDate)
-          if (within) Object.values(m.slots || {}).forEach(t => { if (t) entries.push(`${m.name} ${t} ${m.mealTiming}`) })
+          if (within) Object.values(m.slots || {}).forEach(t => {
+            if (t) entries.push({ name: m.name, time: t, meal: m.mealTiming })
+          })
         }
       })
       list.push({ date, entries })
@@ -208,7 +210,7 @@ export default function Meds () {
               <strong>{d.date}</strong>
               {d.entries.length ? (
                 <ul>
-                  {d.entries.map((e, i) => <li key={i}>{e}</li>)}
+                  {d.entries.map((e, i) => <li key={i}>{e.name} {e.time} {t('meds.meal_' + e.meal)}</li>)}
                 </ul>
               ) : <span> — </span>}
             </li>


### PR DESCRIPTION
## Summary
- Store generated medication schedule entries as `{name, time, meal}` objects
- Render schedule entries with translated meal timing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68aa0a974fe48323984a4fe02450b886