### PR TITLE
Refactor ICS event generation with reusable helpers

### DIFF
--- a/src/lib/ics.js
+++ b/src/lib/ics.js
@@ -1,0 +1,16 @@
+export const detectTZ = () => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  } catch {
+    return 'UTC'
+  }
+}
+
+export const fromDateAndTimeLocal = (date, time = '09:00') => {
+  return new Date(`${date}T${time || '09:00'}:00`)
+}
+
+export const toICSDateTimeUTC = (d) => {
+  const date = d instanceof Date ? d : new Date(d)
+  return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
+}

--- a/src/pages/Meds.jsx
+++ b/src/pages/Meds.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { fromDateAndTimeLocal, toICSDateTimeUTC } from '../lib/ics'
 
 const STORAGE = 'carebee.meds'
 const SLOT_DEFAULTS = { morning: '08:00', noon: '13:00', evening: '20:00' }
@@ -24,10 +25,6 @@ const addDays = (d, n) => {
 }
 
 const esc = v => (v || '').replace(/[\n,;]/g, ' ')
-
-function toICSDateTime (isoDate, hhmm) {
-  return new Date(`${isoDate}T${hhmm || '09:00'}:00`).toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
-}
 
 export default function Meds () {
   const { t } = useTranslation()
@@ -124,8 +121,10 @@ export default function Meds () {
   }, [items, days])
 
   const downloadICS = m => {
-    const dt = toICSDateTime(m.startDate, m.onceTime) || ''
-    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//CareBee//EN\nBEGIN:VEVENT\nUID:${m.id}\nDTSTAMP:${dt}\nDTSTART:${dt}\nSUMMARY:${esc(m.name) || ''}\nEND:VEVENT\nEND:VCALENDAR`
+    const start = fromDateAndTimeLocal(m.startDate, m.onceTime)
+    const dtStart = toICSDateTimeUTC(start)
+    const dtStamp = toICSDateTimeUTC(new Date())
+    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//CareBee//EN\nBEGIN:VEVENT\nUID:${m.id}\nDTSTAMP:${dtStamp}\nDTSTART:${dtStart}\nSUMMARY:${esc(m.name) || ''}\nEND:VEVENT\nEND:VCALENDAR`
     const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' })
     const a = document.createElement('a')
     a.href = URL.createObjectURL(blob)

--- a/src/pages/Visits.jsx
+++ b/src/pages/Visits.jsx
@@ -1,14 +1,12 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { fromDateAndTimeLocal, toICSDateTimeUTC } from '../lib/ics'
 
 const STORAGE = 'carebee.visits'
 const load = (k, def) => { try { const v=localStorage.getItem(k); return v?JSON.parse(v):def } catch { return def } }
 const save = (k, v) => { try { localStorage.setItem(k, JSON.stringify(v)) } catch { /* ignore */ } }
 
 const todayISO = () => { const d=new Date(); const y=d.getFullYear(); const m=String(d.getMonth()+1).padStart(2,'0'); const day=String(d.getDate()).padStart(2,'0'); return `${y}-${m}-${day}` }
-function toICSDateTime (isoDate, hhmm) {
-  return new Date(`${isoDate}T${hhmm || '09:00'}:00`).toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
-}
 
 const esc = v => (v || '').replace(/[\n,;]/g, ' ')
 
@@ -32,12 +30,19 @@ export default function Visits(){
   }
   const remove = (id) => setList(prev=> prev.filter(x=>x.id!==id))
 
-  const upcoming = useMemo(()=> [...list].sort((a,b)=> (a.date+a.time).localeCompare(b.date+b.time)), [list])
+  const upcoming = useMemo(() =>
+    [...list].sort((a, b) =>
+      fromDateAndTimeLocal(a.date, a.time) - fromDateAndTimeLocal(b.date, b.time)
+    ),
+    [list]
+  )
 
   const downloadICS = (v) => {
     const uid = `${v.id}@carebee`
-    const dt = toICSDateTime(v.date, v.time) || ''
-    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//CareBee//EN\nBEGIN:VEVENT\nUID:${uid}\nDTSTAMP:${dt}\nDTSTART:${dt}\nSUMMARY:${esc(`Visit — ${v.doctor}`) || ''}\nLOCATION:${esc(v.place) || ''}\nDESCRIPTION:${esc(v.notes)}\nEND:VEVENT\nEND:VCALENDAR`
+    const start = fromDateAndTimeLocal(v.date, v.time)
+    const dtStart = toICSDateTimeUTC(start)
+    const dtStamp = toICSDateTimeUTC(new Date())
+    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//CareBee//EN\nBEGIN:VEVENT\nUID:${uid}\nDTSTAMP:${dtStamp}\nDTSTART:${dtStart}\nSUMMARY:${esc(`Visit — ${v.doctor}`) || ''}\nLOCATION:${esc(v.place) || ''}\nDESCRIPTION:${esc(v.notes)}\nEND:VEVENT\nEND:VCALENDAR`
     const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' })
     const a = document.createElement('a')
     a.href = URL.createObjectURL(blob)


### PR DESCRIPTION
## Summary
- add timezone and ICS datetime helpers
- use helpers in visits and meds pages for UTC event strings
- sort visits using parsed local datetimes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing errors in unrelated files)*
- `npx eslint src/lib/ics.js src/pages/Visits.jsx src/pages/Meds.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68aa1ba7565c8323a862e8ad95d85e0c