### PR TITLE
feat: highlight today's calendar date with pill

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -45,9 +45,19 @@ form { display: flex; flex-direction: column; gap: 1rem; }
 label { display: flex; flex-direction: column; font-weight: 500; gap: 0.25rem; }
 input, textarea { padding: 0.5rem; font-size: 1rem; border: 1px solid var(--black); border-radius: 4px; }
 
-.today-highlight {
-  background: var(--yellow);
-  color: var(--black);
-  padding: 0 4px;
-  border-radius: 4px;
+.day-cell.is-today {
+  outline: 2px solid var(--brand-blue, #1d8fe1);
+  outline-offset: 2px;
+  background: #eef7ff;
+  border-radius: 10px;
+}
+.today-pill {
+  display:inline-block;
+  margin-left:.5rem;
+  padding:.15rem .5rem;
+  border-radius:999px;
+  background:#1d8fe1;
+  color:#fff;
+  font-size:.8rem;
+  line-height:1;
 }

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -103,9 +103,16 @@ export default function Calendar () {
       {days.map(d => {
         const list = eventsByDate[d]
         return (
-          <div key={d} className='card' style={{ marginBottom: 12 }}>
-            <strong className={d === today ? 'today-highlight' : ''}>
-              {d === today ? t('today', 'Today') : d}
+          <div
+            key={d}
+            className={`card day-cell${d === today ? ' is-today' : ''}`}
+            style={{ marginBottom: 12 }}
+          >
+            <strong>
+              {d}
+              {d === today ? (
+                <span className='today-pill'>{t('today', 'Today')}</span>
+              ) : null}
             </strong>
             {list.length ? (
               <ul>


### PR DESCRIPTION
## Summary
- highlight calendar day using new `.day-cell.is-today` and `.today-pill` styles
- replace previous `today-highlight` usage in Calendar view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error in src/lib/dailySummary.js and src/pages/Vitals.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1bbb0f408323857afb2c5e5bf289