### PR TITLE
Parse dates explicitly to avoid timezone issues

### DIFF
--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -10,8 +10,13 @@ const load = (k, def) => {
   }
 }
 
+const parseISODate = iso => {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+
 const addDays = (date, n) => {
-  const d = new Date(date)
+  const d = parseISODate(date)
   d.setDate(d.getDate() + n)
   return d.toISOString().slice(0, 10)
 }

--- a/src/pages/Meds.jsx
+++ b/src/pages/Meds.jsx
@@ -30,8 +30,13 @@ const save = (k, v) => {
   try { localStorage.setItem(k, JSON.stringify(v)) } catch { /* ignore */ }
 }
 
+const parseISODate = iso => {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+
 const addDays = (d, n) => {
-  const x = new Date(d)
+  const x = parseISODate(d)
   x.setDate(x.getDate() + n)
   return x.toISOString().slice(0, 10)
 }
@@ -118,7 +123,7 @@ export default function Meds () {
 
   const renewals = useMemo(() => {
     const now = today()
-    return items.filter(i => i.mode === 'daily' && i.endDate && (new Date(i.endDate) - new Date(now)) / 86400000 <= 3)
+    return items.filter(i => i.mode === 'daily' && i.endDate && (parseISODate(i.endDate) - parseISODate(now)) / 86400000 <= 3)
   }, [items])
 
   const schedule = useMemo(() => {


### PR DESCRIPTION
## Summary
- Parse ISO date strings manually in meds scheduling utilities
- Parse ISO date strings manually in calendar helpers

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'in' in src/lib/ics.js)*
- `npm run lint` *(fails: Parsing error: Unexpected token in src/lib/dailySummary.js and others)*

------
https://chatgpt.com/codex/tasks/task_e_68aa27496ab483239b0153367f2f9f88