### PR TITLE
Clean up Calendar merge markers and unify day styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,6 @@ form { display: flex; flex-direction: column; gap: 1rem; }
 label { display: flex; flex-direction: column; font-weight: 500; gap: 0.25rem; }
 input, textarea { padding: 0.5rem; font-size: 1rem; border: 1px solid var(--black); border-radius: 4px; }
 
-codex/rename-today-to-todayiso-and-update-styling
 .day-cell {
   margin-bottom: 12px;
 }
@@ -62,21 +61,4 @@ codex/rename-today-to-todayiso-and-update-styling
   border-radius: 4px;
   margin-left: 8px;
   font-size: 0.75rem;
-=======
-.day-cell.is-today {
-  outline: 2px solid var(--brand-blue, #1d8fe1);
-  outline-offset: 2px;
-  background: #eef7ff;
-  border-radius: 10px;
-}
-.today-pill {
-  display:inline-block;
-  margin-left:.5rem;
-  padding:.15rem .5rem;
-  border-radius:999px;
-  background:#1d8fe1;
-  color:#fff;
-  font-size:.8rem;
-  line-height:1;
-main
 }

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -109,44 +109,14 @@ export default function Calendar () {
       {days.map(d => {
         const list = eventsByDate[d]
         return (
-codex/rename-today-to-todayiso-and-update-styling
-          <div key={d} className={`day-cell ${isToday(d) ? 'is-today' : ''}`} aria-current={isToday(d) ? 'date' : undefined}>
-            <div className='card'>
-              <strong>
-                {d}
-                {isToday(d) && <span className='today-pill'>{t('calendar.today')}</span>}
-              </strong>
-              {list.length ? (
-                <ul>
-                  {list.map((e, i) => (
-                    <li key={i}>
-                      {e.time ? `${e.time} ` : ''}{e.title} ({e.type === 'visit' ? t('calendar.visit', 'Visit') : t('calendar.med', 'Med')})
-                      {e.location ? ` — ${e.location}` : ''}
-                      {e.notes ? <div style={{ color: '#555' }}>{e.notes}</div> : null}
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <div>{t('calendar.empty', 'Nothing scheduled')}</div>
-              )}
-            </div>
-=======
-codex/add-today-key-to-locale-files
-          <div key={d} className='card' style={{ marginBottom: 12 }}>
-            <strong className={d === today ? 'today-highlight' : ''}>
-              {d === today ? t('calendar.today', 'Today') : d}
-=======
           <div
             key={d}
-            className={`card day-cell${d === today ? ' is-today' : ''}`}
-            style={{ marginBottom: 12 }}
+            className={`card day-cell${isToday(d) ? ' is-today' : ''}`}
+            aria-current={isToday(d) ? 'date' : undefined}
           >
             <strong>
               {d}
-              {d === today ? (
-                <span className='today-pill'>{t('today', 'Today')}</span>
-              ) : null}
-main
+              {isToday(d) && <span className='today-pill'>{t('calendar.today', 'Today')}</span>}
             </strong>
             {list.length ? (
               <ul>
@@ -161,7 +131,6 @@ main
             ) : (
               <div>{t('calendar.empty', 'Nothing scheduled')}</div>
             )}
-main
           </div>
         )
       })}


### PR DESCRIPTION
## Summary
- remove merge-conflict markers from Calendar.jsx
- consolidate day-cell rendering with `isToday` and `calendar.today` translation
- define matching day-cell, is-today, and today-pill styles in index.css

## Testing
- `npm run lint` *(fails: Parsing errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2ef3f1f48323b74c4b4a556f3db3