### PR TITLE
chore: configure deployment for pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -33,6 +35,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     permissions:
       pages: write
       id-token: write
@@ -40,5 +43,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/configure-pages@v5
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- trigger deployment workflow on pull requests to `main`
- skip deploy job during pull request runs
- configure pages before deployment

## Testing
- `npm test` (fails: SyntaxError in src/lib/ics.js)
- `npm run lint` (fails: parsing errors in src/lib/ics.js, src/pages/Calendar.jsx, src/pages/Visits.jsx)


------
https://chatgpt.com/codex/tasks/task_e_68aa39fd52688323a205665b9500e87b