### PR TITLE
Configure Vite base path based on NODE_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Build for production:
 npm run build
 ```
 
+### Environment
+
+The Vite configuration reads the `NODE_ENV` variable to determine the base
+URL for assets. When `NODE_ENV` is `production` (the default during
+`npm run build`), assets are served from `/CareBee/` to match the GitHub Pages
+deployment. In other environments such as development (`npm run dev`), the
+base path falls back to `/`.
+
 ## Localization
 
 Translations live in the `src/locales` directory. Each language has its own

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,5 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
-  base: '/CareBee/',
+  base: process.env.NODE_ENV === 'production' ? '/CareBee/' : '/',
 })


### PR DESCRIPTION
## Summary
- Set Vite `base` path dynamically so production builds use `/CareBee/` and development uses `/`
- Document the `NODE_ENV`-based base URL behavior in the README

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token '===')*
- `npm run lint` *(fails: Parsing errors in existing files)*
- `npm run build` *(fails: Expression expected in src/App.js)*
- `npm run dev` *(fails: JSX syntax not enabled and other parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa42ef8c60832385df0bad7fc53872