### PR TITLE
feat: handle manual share fallback

### DIFF
--- a/src/components/ShareLink.jsx
+++ b/src/components/ShareLink.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { shareLink } from '../shareLink.js'
 
 export default function ShareLink() {
   const { t } = useTranslation()
@@ -7,21 +8,10 @@ export default function ShareLink() {
   const LINK = 'https://tinyurl.com/carebee24'
 
   const onShare = async () => {
-    try {
-      if (navigator.share) {
-        await navigator.share({
-          title: 'CareBee',
-          text: t('shareText', 'Quick help at your fingertips'),
-          url: LINK,
-        })
-        return
-      }
-      await navigator.clipboard.writeText(LINK)
-      setMsg(t('linkCopied', 'Link copied'))
-      setTimeout(() => setMsg(''), 2000)
-    } catch {
-      setMsg(t('linkCopyFailed', 'Could not share'))
-      setTimeout(() => setMsg(''), 2000)
+    const { msg: message, manual } = await shareLink(navigator, LINK, t)
+    if (message) {
+      setMsg(message)
+      if (!manual) setTimeout(() => setMsg(''), 2000)
     }
   }
 

--- a/src/shareLink.js
+++ b/src/shareLink.js
@@ -1,0 +1,19 @@
+export async function shareLink(nav, link, t) {
+  try {
+    if (nav.share) {
+      await nav.share({
+        title: 'CareBee',
+        text: t('shareText', 'Quick help at your fingertips'),
+        url: link,
+      })
+      return { msg: '', manual: false }
+    }
+    if (nav.clipboard?.writeText) {
+      await nav.clipboard.writeText(link)
+      return { msg: t('linkCopied', 'Link copied'), manual: false }
+    }
+    return { msg: t('manualCopy', `Copy the link manually: ${link}`), manual: true }
+  } catch {
+    return { msg: t('linkCopyFailed', 'Could not share'), manual: false }
+  }
+}

--- a/test/shareLink.test.js
+++ b/test/shareLink.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { shareLink } from '../src/shareLink.js'
+
+const t = (key, defaultText) => defaultText
+
+const LINK = 'https://tinyurl.com/carebee24'
+
+test('falls back to manual copy instructions when clipboard unsupported', async () => {
+  const nav = {}
+  const { msg, manual } = await shareLink(nav, LINK, t)
+  assert.equal(manual, true)
+  assert.equal(msg, `Copy the link manually: ${LINK}`)
+})
+
+test('copies link when clipboard supported', async () => {
+  let written = ''
+  const nav = {
+    clipboard: {
+      writeText: async (text) => { written = text }
+    }
+  }
+  const { msg, manual } = await shareLink(nav, LINK, t)
+  assert.equal(written, LINK)
+  assert.equal(manual, false)
+  assert.equal(msg, 'Link copied')
+})


### PR DESCRIPTION
## Summary
- handle navigator.clipboard absence by requesting manual copy
- centralize share logic in reusable `shareLink` helper
- add tests for clipboard and manual fallback paths

## Testing
- `npm test` (fails: Unexpected token in src/lib/ics.js)
- `npm run lint` (fails: Parsing error: Unexpected token === in various files)


------
https://chatgpt.com/codex/tasks/task_e_68aa42f380c08323b6289063c93ccd64