### PR TITLE
Wrap nav links in list and add ARIA label

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,15 +22,17 @@ export default function App () {
       <header>
         <div className="container header-bar">
           <Link to="/" className="brand">CareBee</Link>
-          <nav className="main-nav" style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
-            <Link to="/profile">{t('nav.profile', 'Profile')}</Link>
-            <Link to="/meds">{t('nav.meds', 'Meds')}</Link>
-            <Link to="/visits">{t('nav.visits', 'Visits')}</Link>
-            <Link to="/calendar">{t('nav.calendar', 'Calendar')}</Link>
-            <Link to="/qr">QR</Link>
-            <Link to="/vitals">Vitals</Link>
-            <Link to="/nearby">Nearby</Link>
-            <LanguageSwitcher />
+          <nav className="main-nav" aria-label="Main">
+            <ul>
+              <li><Link to="/profile">{t('nav.profile', 'Profile')}</Link></li>
+              <li><Link to="/meds">{t('nav.meds', 'Meds')}</Link></li>
+              <li><Link to="/visits">{t('nav.visits', 'Visits')}</Link></li>
+              <li><Link to="/calendar">{t('nav.calendar', 'Calendar')}</Link></li>
+              <li><Link to="/qr">QR</Link></li>
+              <li><Link to="/vitals">Vitals</Link></li>
+              <li><Link to="/nearby">Nearby</Link></li>
+              <li><LanguageSwitcher /></li>
+            </ul>
           </nav>
         </div>
       </header>

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,14 @@ html, body {
 #root, main { min-height: 100%; display: flex; flex-direction: column; }
 header, footer { background: var(--brand-blue); color: #fff; text-align: center; padding: 1rem; }
 header a { color: #fff; text-decoration: none; font-weight: 700; }
+.main-nav ul {
+  list-style: none;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+}
 .container { max-width: 760px; margin: 0 auto; padding: 1rem; }
 .home {
   min-height: calc(100dvh - 140px);


### PR DESCRIPTION
## Summary
- wrap header navigation links in `<ul>`/`<li>` structure
- annotate main navigation with `aria-label="Main"`
- style `.main-nav ul` to display flex with gap

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: Unexpected token refactor-meds)*

------
https://chatgpt.com/codex/tasks/task_e_68aac13e397c8323866f99887e0c4afe