### PR TITLE
Clean up calendar highlighting styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -58,7 +58,6 @@ input, textarea { padding: 0.5rem; font-size: 1rem; border: 1px solid var(--blac
 }
 
 .day-cell.is-today {
-codex/clean-up-css-styles-in-index.css
   outline: 2px solid var(--brand-blue);
   outline-offset: 2px;
   background: #eef7ff;
@@ -74,17 +73,4 @@ codex/clean-up-css-styles-in-index.css
   color: #fff;
   font-size: .8rem;
   line-height: 1;
-=======
-  outline: 2px solid var(--yellow);
-  border-radius: 8px;
-}
-
-.today-pill {
-  background: var(--yellow);
-  color: var(--black);
-  padding: 0 4px;
-  border-radius: 4px;
-  margin-left: 8px;
-  font-size: 0.75rem;
-main
 }


### PR DESCRIPTION
## Summary
- resolve CSS merge artifacts in `index.css`
- keep brand-blue styles for `.day-cell.is-today` and `.today-pill`

## Testing
- `npx postcss-cli src/index.css -o /tmp/index.css`
- `npm test`
- `npm run lint` *(fails: Parsing error: Unexpected token refactor-meds, codex not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aaede842348323bc599469365bb7ee