### PR TITLE
fix: clean up visits save helper

### DIFF
--- a/src/pages/Visits.jsx
+++ b/src/pages/Visits.jsx
@@ -4,10 +4,7 @@ import { buildGoogleCalLink, buildICSEvent, fromDateAndTimeLocal, toICSDateTimeU
 
 const STORAGE = 'carebee.visits'
 const load = (k, def) => { try { const v = localStorage.getItem(k); return v ? JSON.parse(v) : def } catch { return def } }
-codex/refactor-meds.jsx-and-verify-medication-rendering
 const save = (k, v) => { try { localStorage.setItem(k, JSON.stringify(v)) } catch { /* ignore */ } }
-const save = (k, v) => { try { localStorage.setItem(k, JSON.stringify(v)) } catch { /* empty */ } }
-main
 
 const todayISO = () => { const d = new Date(); const y = d.getFullYear(); const m = String(d.getMonth() + 1).padStart(2, '0'); const day = String(d.getDate()).padStart(2, '0'); return `${y}-${m}-${day}`; }
 


### PR DESCRIPTION
## Summary
- remove stray placeholder and duplicate save helper in visits page

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error in Calendar.jsx; no-undef in Meds.jsx, process undefined in tests and vite config)*

------
https://chatgpt.com/codex/tasks/task_e_68aaede5f5d48323a36aa5255dad97f3