### PR TITLE
Refactor daily summary auto-send settings

### DIFF
--- a/src/lib/dailySummary.js
+++ b/src/lib/dailySummary.js
@@ -13,7 +13,11 @@ const load = (k, def) => {
   }
 }
 
-const loadProfile = () => load(PROFILE_KEY, {})
+const loadProfile = () => {
+  const p = load(PROFILE_KEY, {})
+  const { autosendEnabled: _ae, autosendTime: _at, ...rest } = p || {}
+  return rest
+}
 
 export function getAutoSendSettings () {
   return load(AUTO_KEY, { enabled: false, time: '08:00' })
@@ -38,13 +42,13 @@ export function getLastSummaryAt () {
 
 export function shouldAutoSend () {
   try {
-    const p = loadProfile()
-    if (!p.autosendEnabled) return false
+    const { enabled, time } = getAutoSendSettings()
+    if (!enabled) return false
     const now = new Date()
     const hhmm = now.toTimeString().slice(0, 5)
     const today = now.toISOString().slice(0, 10)
     const last = localStorage.getItem(LAST_KEY)
-    return hhmm >= (p.autosendTime || '00:00') && last !== today
+    return hhmm >= (time || '00:00') && last !== today
   } catch {
     return false
   }

--- a/test/dailySummary.test.js
+++ b/test/dailySummary.test.js
@@ -16,7 +16,7 @@ test('maybeSendDailySummary uses translated confirmation', async () => {
     setItem: (k, v) => store.set(k, v),
     removeItem: k => store.delete(k)
   }
-  store.set('carebee.profile', JSON.stringify({ autosendEnabled: true, autosendTime: '00:00' }))
+  store.set('carebee.autosend', JSON.stringify({ enabled: true, time: '00:00' }))
 
   globalThis.window = { open: () => {} }
   let message


### PR DESCRIPTION
## Summary
- Load auto-send settings via `getAutoSendSettings` instead of profile lookup
- Strip obsolete auto-send fields from profile data
- Update tests to configure auto-send using new storage key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab105954948323bd87a8317607d6d4