### PR TITLE
Persist selected language

### DIFF
--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -3,7 +3,14 @@ export default function LanguageSwitcher() {
   const { i18n } = useTranslation()
   const current = (i18n.resolvedLanguage || i18n.language || 'en').slice(0,2)
   return (
-    <select value={current} onChange={(e) => i18n.changeLanguage(e.target.value)}>
+    <select
+      value={current}
+      onChange={(e) => {
+        const newLang = e.target.value
+        i18n.changeLanguage(newLang)
+        localStorage.setItem("lng", newLang)
+      }}
+    >
       <option value="en">EN</option>
       <option value="ru">RU</option>
       <option value="fr">FR</option>


### PR DESCRIPTION
## Summary
- persist the chosen interface language by saving it to localStorage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af832762188323a196913c00a803dd