### PR TITLE
Refactor auto-send logic and add coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "postbuild": "node -e \"require('fs').copyFileSync('dist/index.html','dist/404.html')\""
+    "postbuild": "node -e \"require('fs').copyFileSync('dist/index.html','dist/404.html')\"",
+    "test": "node --test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.56.0",

--- a/src/lib/dailySummary.js
+++ b/src/lib/dailySummary.js
@@ -55,19 +55,14 @@ function sameLocalDate(a, b) {
 }
 
 export function shouldAutoSend(now = new Date()) {
-  const { enabled, time } = getAutoSendSettings();
-  if (!enabled) return false;
+  const settings = getAutoSendSettings();
+  if (!settings.enabled) return false;
 
   const last = getLastSummaryAt();
-  const lastDate = last ? new Date(last) : null;
+  if (last && sameLocalDate(new Date(last), now)) return false;
 
-  const target = todayAt(time);
-  const isTimePassed = now.getTime() >= target.getTime();
-
-  // если сегодня уже отправляли — не отправляем
-  if (lastDate && sameLocalDate(lastDate, now)) return false;
-
-  return isTimePassed;
+  const target = todayAt(settings.time);
+  return now.getTime() >= target.getTime();
 }
 
 export function maybeSendDailySummary(now = new Date()) {

--- a/src/lib/dailySummary.test.js
+++ b/src/lib/dailySummary.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function createLocalStorage() {
+  const store = {};
+  return {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    setItem(key, value) {
+      store[key] = String(value);
+    },
+    removeItem(key) {
+      delete store[key];
+    },
+    clear() {
+      for (const k in store) delete store[k];
+    },
+  };
+}
+
+test('shouldAutoSend uses auto-send settings rather than profile', async () => {
+  global.localStorage = createLocalStorage();
+  // profile contains legacy autosend fields which should be ignored
+  localStorage.setItem('carebee.profile', JSON.stringify({
+    autosendEnabled: true,
+    autosendTime: '05:00',
+  }));
+
+  const { shouldAutoSend, setAutoSendSettings } = await import('./dailySummary.js');
+  // Prepare a consistent "now" based on today's date
+  const now = new Date();
+  now.setHours(9, 0, 0, 0);
+
+  // With default settings (enabled=false) it should not send
+  assert.equal(shouldAutoSend(now), false);
+
+  // Enabling via settings should allow auto-send irrespective of profile
+  setAutoSendSettings({ enabled: true, time: '08:00' });
+  assert.equal(shouldAutoSend(now), true);
+});

--- a/src/pages/Vitals.jsx
+++ b/src/pages/Vitals.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { maybeSendDailySummary } from "../lib/dailySummary.js";
 
 const load = (k, def) => { try { const v = localStorage.getItem(k); return v ? JSON.parse(v) : def; } catch { return def; } };
 const save = (k, v) => localStorage.setItem(k, JSON.stringify(v));
@@ -18,6 +19,7 @@ export default function Vitals() {
     const next = [...items, { ...form }];
     next.sort((a,b)=> (a.date+a.time).localeCompare(b.date+b.time));
     setItems(next); save("carebee.vitals", next);
+    maybeSendDailySummary();
     setForm({ type: form.type, value:"", date: todayStr(), time: timeStr(), notes:"" });
   };
 


### PR DESCRIPTION
## Summary
- refactor `shouldAutoSend` to rely on `getAutoSendSettings`
- trigger auto-send from Vitals page using unified API
- add node tests and npm script for auto-send settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af862d01f08323b4a97b954a8a0516