### PR TITLE
ci: update deploy workflow paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,20 +26,16 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: pages/package-lock.json
+          cache-dependency-path: package-lock.json
 
       # если у тебя нет package-lock.json — можно заменить на `npm install`
       - name: Install deps
-        working-directory: pages
         run: npm ci
 
       - run: npm run lint
-        working-directory: pages
       - run: npm test
-        working-directory: pages
 
       - name: Build
-        working-directory: pages
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
@@ -52,7 +48,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: pages/dist
+          path: dist
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- update cache dependency path to package-lock.json
- run build steps from repository root
- upload built artifact from dist directory

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68af879f6bec8323b415b2b20aae31a5