### PR TITLE
Use HashRouter-based routing with SOS navigation

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,12 @@
 // src/main.jsx
 import React from "react";
 import ReactDOM from "react-dom/client";
-import AppMini from "./AppMini"; // ← ПОДКЛЮЧАЕМ MINI
+import App from "./App";
 
 console.log("[BOOT] main.jsx • BASE_URL =", import.meta.env.BASE_URL);
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <AppMini />
+    <App />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- switch entry point to App using HashRouter
- navigate between Home and SOS pages with redirect for unknown routes
- add large centered SOS button on Home page linking to SOS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68af82a93c70832395ce5dbc03a503ab