### PR TITLE
refactor: move sos styles to css

### DIFF
--- a/src/components/Sos.css
+++ b/src/components/Sos.css
@@ -1,0 +1,19 @@
+.sos-container {
+  min-height: 70vh;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+
+.sos-button {
+  width: 18rem;
+  height: 18rem;
+  border-radius: 9999px;
+  background: #dc2626;
+  color: #fff;
+  font-weight: 800;
+  font-size: 56px;
+  box-shadow: 0 20px 50px -12px rgba(220, 38, 38, 0.6);
+  border: 8px solid rgba(248, 113, 113, 0.5);
+  cursor: pointer;
+}

--- a/src/components/Sos.jsx
+++ b/src/components/Sos.jsx
@@ -1,0 +1,18 @@
+// src/components/Sos.jsx
+import "./Sos.css";
+
+export default function Sos() {
+  const click = () => alert("SOS test — кнопка работает ✅");
+  return (
+    <main className="sos-container">
+      <button
+        onClick={click}
+        type="button"
+        aria-label="SOS"
+        className="sos-button"
+      >
+        SOS
+      </button>
+    </main>
+  );
+}

--- a/src/pages/Sos.jsx
+++ b/src/pages/Sos.jsx
@@ -1,21 +1,2 @@
 // src/pages/Sos.jsx
-export default function Sos() {
-  const click = () => alert("SOS test — кнопка работает ✅");
-  return (
-    <main style={{minHeight:"70vh", display:"grid", placeItems:"center", padding:16}}>
-      <button
-        onClick={click}
-        type="button"
-        aria-label="SOS"
-        style={{
-          width:"18rem", height:"18rem", borderRadius:"9999px",
-          background:"#dc2626", color:"#fff", fontWeight:800, fontSize:"56px",
-          boxShadow:"0 20px 50px -12px rgba(220,38,38,.6)",
-          border:"8px solid rgba(248,113,113,.5)", cursor:"pointer"
-        }}
-      >
-        SOS
-      </button>
-    </main>
-  );
-}
+export { default } from "../components/Sos";


### PR DESCRIPTION
## Summary
- create Sos.css with styles for container and button
- refactor Sos component to use CSS classes and export from pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af89bd449c8323865b77958b109acc