### PR TITLE
Remove redundant aria-label from SOS button

### DIFF
--- a/src/pages/Sos.jsx
+++ b/src/pages/Sos.jsx
@@ -6,7 +6,6 @@ export default function Sos() {
       <button
         onClick={click}
         type="button"
-        aria-label="SOS"
         style={{
           width:"18rem", height:"18rem", borderRadius:"9999px",
           background:"#dc2626", color:"#fff", fontWeight:800, fontSize:"56px",


### PR DESCRIPTION
## Summary
- drop unnecessary `aria-label` from SOS button and rely on its text for accessibility

## Testing
- `node -e "const {JSDOM}=require('jsdom');const {computeAccessibleName}=require('dom-accessibility-api');const dom=new JSDOM('<button>SOS</button>');const btn=dom.window.document.querySelector('button');console.log(computeAccessibleName(btn));"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af89c1861c8323afe601518ea4f8a0