### PR TITLE
chore: remove aria-label from SOS button

### DIFF
--- a/src/components/Sos.jsx
+++ b/src/components/Sos.jsx
@@ -1,4 +1,3 @@
-codex/remove-alert-and-implement-accessible-notification
 import { useEffect, useRef, useState } from "react";
 
 export default function Sos() {
@@ -33,17 +32,22 @@ export default function Sos() {
   }, [active]);
 
   return (
-    <main style={{minHeight:"70vh", display:"grid", placeItems:"center", padding:16}}>
+    <main style={{ minHeight: "70vh", display: "grid", placeItems: "center", padding: 16 }}>
       <button
         ref={buttonRef}
         onClick={open}
         type="button"
-        aria-label="SOS"
         style={{
-          width:"18rem", height:"18rem", borderRadius:"9999px",
-          background:"#dc2626", color:"#fff", fontWeight:800, fontSize:"56px",
-          boxShadow:"0 20px 50px -12px rgba(220,38,38,.6)",
-          border:"8px solid rgba(248,113,113,.5)", cursor:"pointer"
+          width: "18rem",
+          height: "18rem",
+          borderRadius: "9999px",
+          background: "#dc2626",
+          color: "#fff",
+          fontWeight: 800,
+          fontSize: "56px",
+          boxShadow: "0 20px 50px -12px rgba(220,38,38,.6)",
+          border: "8px solid rgba(248,113,113,.5)",
+          cursor: "pointer",
         }}
       >
         SOS
@@ -55,48 +59,48 @@ export default function Sos() {
           aria-modal="true"
           aria-labelledby="sos-title"
           style={{
-            position:"fixed", inset:0, display:"grid", placeItems:"center",
-            background:"rgba(0,0,0,0.5)",
+            position: "fixed",
+            inset: 0,
+            display: "grid",
+            placeItems: "center",
+            background: "rgba(0,0,0,0.5)",
           }}
         >
           <div
             style={{
-              background:"#fff", padding:24, borderRadius:8, textAlign:"center",
-              maxWidth:320, boxShadow:"0 10px 25px rgba(0,0,0,0.2)"
+              background: "#fff",
+              padding: 24,
+              borderRadius: 8,
+              textAlign: "center",
+              maxWidth: 320,
+              boxShadow: "0 10px 25px rgba(0,0,0,0.2)",
             }}
           >
-            <h2 id="sos-title" style={{fontSize:24, marginBottom:16}}>SOS activated</h2>
-            <p style={{marginBottom:24}}>Emergency services have been notified.</p>
+            <h2 id="sos-title" style={{ fontSize: 24, marginBottom: 16 }}>
+              SOS activated
+            </h2>
+            <p style={{ marginBottom: 24 }}>
+              Emergency services have been notified.
+            </p>
             <button
               ref={closeButtonRef}
               onClick={close}
               type="button"
               style={{
-                padding:"8px 16px", background:"#dc2626", color:"#fff",
-                border:"none", borderRadius:4, cursor:"pointer"
+                padding: "8px 16px",
+                background: "#dc2626",
+                color: "#fff",
+                border: "none",
+                borderRadius: 4,
+                cursor: "pointer",
               }}
             >
               Close
             </button>
           </div>
         </div>
-      )}========
-// src/components/Sos.jsx
-import "./Sos.css";
-
-export default function Sos() {
-  const click = () => alert("SOS test — кнопка работает ✅");
-  return (
-    <main className="sos-container">
-      <button
-        onClick={click}
-        type="button"
-        aria-label="SOS"
-        className="sos-button"
-      >
-        SOS
-      </button>
-main
+      )}
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- remove redundant aria-label from SOS button so visible text provides its accessible name

## Testing
- `node -e "const React=require('react'); const ReactDOMServer=require('react-dom/server'); const Sos=require('./tmp-sos.cjs').default; const html=ReactDOMServer.renderToString(React.createElement(Sos)); const {JSDOM}=require('jsdom'); const {getByRole}=require('@testing-library/dom'); const dom=new JSDOM(html); const button=getByRole(dom.window.document.body,'button',{name:'SOS'}); console.log('Accessible name:', button.textContent);"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8ee915b4832386308d1b6eabb9a5