### PR TITLE
Use i18n translations for navigation links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,11 @@
 // src/App.jsx
 import { HashRouter as Router, Routes, Route, Link, Navigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import Home from "./pages/Home";
 import Sos from "./pages/Sos";
 
 export default function App() {
+  const { t } = useTranslation();
   return (
     <Router>
       <header style={{
@@ -11,8 +13,8 @@ export default function App() {
         borderBottom:"1px solid #f0d48a", padding:"8px 12px"
       }}>
         <nav style={{display:"flex",gap:12,fontSize:14}}>
-          <Link to="/">Home</Link>
-          <Link to="/sos">SOS</Link>
+          <Link to="/">{t('nav.home', 'Home')}</Link>
+          <Link to="/sos">{t('nav.sos', 'SOS')}</Link>
         </nav>
       </header>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,6 @@
 {
   "app": { "title": "CareBee" },
-  "nav": { "profile": "Profile", "meds": "Meds", "visits": "Visits", "calendar": "Calendar", "vitals": "Vitals", "nearby": "Nearby" },
+  "nav": { "home": "Home", "sos": "SOS", "profile": "Profile", "meds": "Meds", "visits": "Visits", "calendar": "Calendar", "vitals": "Vitals", "nearby": "Nearby" },
   "today": "Today",
   "actions": { "add": "Add", "save": "Save", "delete": "Delete", "cancel": "Cancel", "clear":"Clear" },
   "fields": { "name":"Name", "dose":"Dose", "mode":"Mode", "date":"Date", "time":"Time", "start":"Start", "end":"End", "times":"Times", "doctor":"Doctor", "place":"Place", "notes":"Notes", "value":"Value", "type":"Type", "address":"Address", "phone":"Phone" },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,6 +1,6 @@
 {
   "app": { "title": "CareBee" },
-  "nav": { "profile": "Profil", "meds": "Médicaments", "visits": "Visites", "calendar": "Calendrier", "vitals": "Signes vitaux", "nearby": "À proximité" },
+  "nav": { "home": "Accueil", "sos": "SOS", "profile": "Profil", "meds": "Médicaments", "visits": "Visites", "calendar": "Calendrier", "vitals": "Signes vitaux", "nearby": "À proximité" },
   "today": "Aujourd'hui",
   "actions": { "add": "Ajouter", "save": "Enregistrer", "delete": "Supprimer", "cancel": "Annuler", "clear":"Effacer" },
   "fields": { "name":"Nom", "dose":"Dose", "mode":"Mode", "date":"Date", "time":"Heure", "start":"Début", "end":"Fin", "times":"Heures", "doctor":"Médecin", "place":"Lieu", "notes":"Notes", "value":"Valeur", "type":"Type", "address":"Adresse", "phone":"Téléphone" },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,6 +1,6 @@
 {
   "app": { "title": "CareBee" },
-  "nav": { "profile": "Профиль", "meds": "Препараты", "visits": "Визиты", "calendar": "Календарь", "vitals": "Показатели", "nearby": "Рядом" },
+  "nav": { "home": "Главная", "sos": "SOS", "profile": "Профиль", "meds": "Препараты", "visits": "Визиты", "calendar": "Календарь", "vitals": "Показатели", "nearby": "Рядом" },
   "today": "Сегодня",
   "actions": { "add": "Добавить", "save": "Сохранить", "delete": "Удалить", "cancel": "Отмена", "clear":"Очистить" },
   "fields": { "name":"Название", "dose":"Дозировка", "mode":"Режим", "date":"Дата", "time":"Время", "start":"Начало", "end":"Конец", "times":"Время", "doctor":"Врач", "place":"Место", "notes":"Заметки", "value":"Значение", "type":"Тип", "address":"Адрес", "phone":"Телефон" },


### PR DESCRIPTION
## Summary
- use `useTranslation` to localize nav links in `App`
- add `nav.home` and `nav.sos` keys to English, French, and Russian locale files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8e03b1648323926cd23854e243c8