### PR TITLE
Fix SOS button className token

### DIFF
--- a/src/components/Sos.jsx
+++ b/src/components/Sos.jsx
@@ -15,7 +15,7 @@ export default function Sos() {
         ref={buttonRef}
         onClick={() => setActive(true)}
         type="button"
-        className="w-72 h-72 rounded-full bg-red-600 text-white text-6xl font-extrabold shadow-xl border-8 border-red-300 focus:outline-none"
+        className={`w-72 h-72 rounded-full bg-red-600 text-white text-6xl font-extrabold shadow-xl border-8 border-red-300 focus:outline-none`}
       >
         SOS
       </button>


### PR DESCRIPTION
## Summary
- use template literal on SOS button so `focus:outline-none` is contiguous

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b000c8b8d48323af20c8a4962c7501