### PR TITLE
feat: add storage helpers

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,0 +1,16 @@
+export function load(key, def) {
+  try {
+    const v = localStorage.getItem(key);
+    return v ? JSON.parse(v) : def;
+  } catch {
+    return def;
+  }
+}
+
+export function save(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore write errors
+  }
+}

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { load, save } from "../lib/storage.js";
 
-const load = (k, def) => { try { const v = localStorage.getItem(k); return v ? JSON.parse(v) : def; } catch { return def; } };
-const save = (k, v) => localStorage.setItem(k, JSON.stringify(v));
 const todayStr = () => new Date().toISOString().slice(0,10);
 const addDays = (d, n) => { const dt = new Date(d); dt.setDate(dt.getDate()+n); return dt.toISOString().slice(0,10); };
 

--- a/src/pages/Meds.jsx
+++ b/src/pages/Meds.jsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { load, save } from "../lib/storage.js";
 
-const load = (k, def) => { try { const v = localStorage.getItem(k); return v ? JSON.parse(v) : def; } catch { return def; } };
-const save = (k, v) => localStorage.setItem(k, JSON.stringify(v));
 const todayStr = () => new Date().toISOString().slice(0, 10);
 
 export default function Meds() {

--- a/src/pages/Visits.jsx
+++ b/src/pages/Visits.jsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { load, save } from "../lib/storage.js";
 
-const load = (k, def) => { try { const v = localStorage.getItem(k); return v ? JSON.parse(v) : def; } catch { return def; } };
-const save = (k, v) => localStorage.setItem(k, JSON.stringify(v));
 const todayStr = () => new Date().toISOString().slice(0, 10);
 
 export default function Visits() {

--- a/src/pages/Vitals.jsx
+++ b/src/pages/Vitals.jsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { maybeSendDailySummary } from "../lib/dailySummary.js";
+import { load, save } from "../lib/storage.js";
 
-const load = (k, def) => { try { const v = localStorage.getItem(k); return v ? JSON.parse(v) : def; } catch { return def; } };
-const save = (k, v) => localStorage.setItem(k, JSON.stringify(v));
 const todayStr = () => new Date().toISOString().slice(0, 10);
 const timeStr  = () => new Date().toTimeString().slice(0,5);
 


### PR DESCRIPTION
## Summary
- centralize localStorage helpers with error handling
- refactor Meds, Visits, Vitals, and Calendar pages to use new storage module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b000cba3048323a839c088ab3d4af7