### PR TITLE
Handle missing clipboard in ShareLink

### DIFF
--- a/src/components/ShareLink.jsx
+++ b/src/components/ShareLink.jsx
@@ -16,11 +16,15 @@ export default function ShareLink() {
         })
         return
       }
-      await navigator.clipboard.writeText(LINK)
-      setMsg(t('linkCopied', 'Link copied'))
-      setTimeout(() => setMsg(''), 2000)
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(LINK)
+        setMsg(t('linkCopied', 'Link copied'))
+        setTimeout(() => setMsg(''), 2000)
+        return
+      }
+      throw new Error('Clipboard unavailable')
     } catch {
-      setMsg(t('linkCopyFailed', 'Could not share'))
+      setMsg(t('linkCopyFailed', 'Could not share. Please copy the link manually.'))
       setTimeout(() => setMsg(''), 2000)
     }
   }


### PR DESCRIPTION
## Summary
- Safeguard `ShareLink` sharing by verifying `navigator.clipboard?.writeText` before use
- Provide a clearer error prompting manual copy when sharing fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b000cd50208323b210633785569fb7