### PR TITLE
Simplify Vite config and remove Vitest settings

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,7 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig({
   plugins: [react()],
-  base: command === "serve" ? "/" : "/CareBee/",
-  test: {
-    environment: "jsdom",
-    setupFiles: "./tests/setup.js",
-    globals: true,
-  },
-}));
+  base: "/CareBee/",
+});


### PR DESCRIPTION
## Summary
- Replace `vitest/config` with `vite`
- Remove conditional base and Vitest options
- Export `defineConfig` with `react()` plugin and `base: '/CareBee/'`

## Testing
- `npm test` *(fails: ReferenceError: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b01dafc11c832380ac71ba25d37202