### PR TITLE
Sync HTML lang attribute with i18n language

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,13 +4,31 @@ import en from "./locales/en.json";
 import ru from "./locales/ru.json";
 import fr from "./locales/fr.json";
 
-const saved = localStorage.getItem("lng") || "en";
+const resources = {
+  en: { translation: en },
+  ru: { translation: ru },
+  fr: { translation: fr },
+};
+
+const savedLang = localStorage.getItem("lang") || "en";
+
+const updateHtmlLang = (lng) => {
+  if (typeof document !== "undefined") {
+    document.documentElement.lang = lng;
+  }
+  localStorage.setItem("lang", lng);
+};
 
 i18n.use(initReactI18next).init({
-  lng: saved,
+  resources,
+  lng: savedLang,
   fallbackLng: "en",
-  supportedLngs: ["en","ru","fr"],
-  resources: { en:{translation:en}, ru:{translation:ru}, fr:{translation:fr} },
+  supportedLngs: ["en", "ru", "fr"],
   interpolation: { escapeValue: false },
 });
+
+updateHtmlLang(i18n.language);
+
+i18n.on("languageChanged", updateHtmlLang);
+
 export default i18n;


### PR DESCRIPTION
## Summary
- Initialize i18next with English, Russian, and French resources
- Read `lang` from localStorage and set it as the initial language
- Keep `<html lang>` and localStorage in sync whenever the language changes

## Testing
- `npm test` *(fails: ReferenceError: expect is not defined in tests/pages/Sos.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b07526b65883238cc67dc62495a7b7