### PR TITLE
Add home SOS and footer translations

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,5 +31,7 @@
     "category": "Category",
     "categories": { "doctor":"Doctor", "clinic":"Clinic", "pharmacy":"Pharmacy", "other":"Other" },
     "openInMaps": "Open in Maps"
-  }
+  },
+  "home": { "sos": "Open SOS" },
+  "footer": { "copyright": "\u00a9 2024 CareBee" }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -31,5 +31,7 @@
     "category": "Catégorie",
     "categories": { "doctor":"Médecin", "clinic":"Clinique", "pharmacy":"Pharmacie", "other":"Autre" },
     "openInMaps": "Ouvrir dans Maps"
-  }
+  },
+  "home": { "sos": "Ouvrir SOS" },
+  "footer": { "copyright": "\u00a9 2024 CareBee" }
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -31,5 +31,7 @@
     "category": "Категория",
     "categories": { "doctor":"Врач", "clinic":"Клиника", "pharmacy":"Аптека", "other":"Другое" },
     "openInMaps": "Открыть в Картах"
-  }
+  },
+  "home": { "sos": "Открыть SOS" },
+  "footer": { "copyright": "\u00a9 2024 CareBee" }
 }


### PR DESCRIPTION
## Summary
- provide `home.sos` translation entries
- add `footer` copyright translations across locales

## Testing
- `npm test` *(fails: ReferenceError: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b07528083083239f0d1dbda8aaf4da