### PR TITLE
feat: import i18n in main entry

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import "./i18n";
 
 console.log("[BOOT] main.jsx • BASE_URL =", import.meta.env.BASE_URL);
 


### PR DESCRIPTION
## Summary
- ensure i18n initialization by importing `./i18n` in `main.jsx`

## Testing
- `npm test` *(fails: ReferenceError: expect is not defined in tests/pages/Sos.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b07529032c83239c0613bf03a864b1