### PR TITLE
feat: style language switcher

### DIFF
--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -1,22 +1,24 @@
 import { useTranslation } from 'react-i18next'
+
 export default function LanguageSwitcher() {
   const { i18n } = useTranslation()
-  const current = (i18n.resolvedLanguage || i18n.language || 'en').slice(0,2)
+  const current = (i18n.resolvedLanguage || i18n.language || 'en').slice(0, 2)
+
+  const changeLanguage = (e) => {
+    const lang = e.target.value
+    i18n.changeLanguage(lang)
+    localStorage.setItem('lng', lang)
+  }
+
   return (
-    <label>
-      Language
-      <select
-        value={current}
-        onChange={(e) => {
-          const newLang = e.target.value
-          i18n.changeLanguage(newLang)
-          localStorage.setItem("lng", newLang)
-        }}
-      >
-        <option value="en">EN</option>
-        <option value="ru">RU</option>
-        <option value="fr">FR</option>
-      </select>
-    </label>
+    <select
+      className="select select-bordered"
+      value={current}
+      onChange={changeLanguage}
+    >
+      <option value="en">EN</option>
+      <option value="ru">RU</option>
+      <option value="fr">FR</option>
+    </select>
   )
 }


### PR DESCRIPTION
## Summary
- switch to styled select for language choices
- persist language selection to localStorage

## Testing
- `npm test` *(fails: ReferenceError: expect is not defined in tests/pages/Sos.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0752a578c8323b8402b4c492a9088