### PR TITLE
Add localized footer and expanded routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
-// src/App.jsx
-import { HashRouter as Router, Routes, Route, NavLink, Navigate } from "react-router-dom";
+import { HashRouter as Router, Routes, Route, NavLink, Navigate, Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import LanguageSwitcher from "./components/LanguageSwitcher";
 
-// ПОДКЛЮЧАЕМ СТРАНИЦЫ ИЗ src/pages/
+// PAGES
 import Home from "./pages/Home";
 import Profile from "./pages/Profile";
 import Meds from "./pages/Meds";
@@ -10,10 +11,7 @@ import Calendar from "./pages/Calendar";
 import Vitals from "./pages/Vitals";
 import Nearby from "./pages/Nearby";
 
-/**
- * Встроенная страница SOS (большая кнопка).
- * Никаких внешних файлов не нужно: даже если src/pages/Sos.jsx удалён, маршрут /sos работает.
- */
+// Built‑in SOS page with rectangular button
 function SosPage() {
   const click = () => alert("SOS sent (test) ✅");
   return (
@@ -22,8 +20,7 @@ function SosPage() {
         onClick={click}
         type="button"
         aria-label="SOS"
-        style={{ width: "18rem", height: "18rem" }}
-        className="rounded-full bg-red-600 text-white text-5xl font-extrabold
+        className="w-64 h-32 rounded-lg bg-red-600 text-white text-5xl font-extrabold
                    shadow-[0_20px_50px_-12px_rgba(220,38,38,0.6)] ring-4 ring-red-300/50
                    hover:bg-red-700 active:scale-95 focus:outline-none focus:ring-8
                    focus:ring-red-400/60 select-none"
@@ -34,13 +31,19 @@ function SosPage() {
   );
 }
 
-// Небольшой помощник для активного пункта меню
+// Minimal placeholder pages
+const FaqPage = () => <main className="p-4 max-w-2xl mx-auto">FAQ</main>;
+const PrivacyPage = () => <main className="p-4 max-w-2xl mx-auto">Privacy</main>;
+const GuidePage = () => <main className="p-4 max-w-2xl mx-auto">Guide</main>;
+
+// Helper for active navigation link
 function LinkItem({ to, children }) {
   return (
     <NavLink
       to={to}
       className={({ isActive }) =>
-        "px-3 py-1 rounded " + (isActive ? "bg-yellow-200 font-semibold" : "hover:bg-yellow-100")
+        "px-3 py-1 rounded " +
+        (isActive ? "bg-yellow-200 font-semibold" : "hover:bg-yellow-100")
       }
       end
     >
@@ -50,41 +53,61 @@ function LinkItem({ to, children }) {
 }
 
 export default function App() {
+  const { t } = useTranslation();
+
   return (
     <Router>
-      {/* ШАПКА-НАВИГАЦИЯ */}
+      {/* HEADER WITH NAVIGATION */}
       <header
         style={{ position: "sticky", top: 0, zIndex: 10 }}
         className="bg-amber-50 border-b border-amber-200"
       >
-        <nav className="max-w-6xl mx-auto flex flex-wrap gap-2 p-2 text-sm">
-          <LinkItem to="/">Home</LinkItem>
-          <LinkItem to="/profile">Profile</LinkItem>
-          <LinkItem to="/meds">Meds</LinkItem>
-          <LinkItem to="/visits">Visits</LinkItem>
-          <LinkItem to="/calendar">Calendar</LinkItem>
-          <LinkItem to="/vitals">Vitals</LinkItem>
-          <LinkItem to="/nearby">Nearby</LinkItem>
-          <LinkItem to="/sos">SOS</LinkItem>
-        </nav>
+        <div className="max-w-6xl mx-auto flex flex-wrap items-center gap-2 p-2 text-sm">
+          <nav className="flex flex-wrap gap-2 grow">
+            <LinkItem to="/">{t("nav.home")}</LinkItem>
+            <LinkItem to="/profile">{t("nav.profile")}</LinkItem>
+            <LinkItem to="/meds">{t("nav.meds")}</LinkItem>
+            <LinkItem to="/visits">{t("nav.visits")}</LinkItem>
+            <LinkItem to="/calendar">{t("nav.calendar")}</LinkItem>
+            <LinkItem to="/vitals">{t("nav.vitals")}</LinkItem>
+            <LinkItem to="/nearby">{t("nav.nearby")}</LinkItem>
+            <LinkItem to="/sos">{t("nav.sos")}</LinkItem>
+          </nav>
+          <LanguageSwitcher />
+        </div>
       </header>
 
-      {/* МАРШРУТЫ */}
+      {/* ROUTES */}
       <Routes>
         <Route path="/" element={<Home />} />
-
         <Route path="/profile" element={<Profile />} />
         <Route path="/meds" element={<Meds />} />
         <Route path="/visits" element={<Visits />} />
         <Route path="/calendar" element={<Calendar />} />
         <Route path="/vitals" element={<Vitals />} />
         <Route path="/nearby" element={<Nearby />} />
-
         <Route path="/sos" element={<SosPage />} />
-
-        {/* Любой другой путь → на Home */}
+        <Route path="/faq" element={<FaqPage />} />
+        <Route path="/privacy" element={<PrivacyPage />} />
+        <Route path="/guide" element={<GuidePage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+
+      {/* FOOTER */}
+      <footer className="bg-amber-50 border-t border-amber-200 mt-8 p-4 text-sm">
+        <nav className="flex justify-center gap-4">
+          <Link to="/guide" className="text-blue-600 hover:underline">
+            {t("footer.guide")}
+          </Link>
+          <Link to="/faq" className="text-blue-600 hover:underline">
+            {t("footer.faq")}
+          </Link>
+          <Link to="/privacy" className="text-blue-600 hover:underline">
+            {t("footer.privacy")}
+          </Link>
+        </nav>
+      </footer>
     </Router>
   );
 }
+

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,5 +31,6 @@
     "category": "Category",
     "categories": { "doctor":"Doctor", "clinic":"Clinic", "pharmacy":"Pharmacy", "other":"Other" },
     "openInMaps": "Open in Maps"
-  }
+  },
+  "footer": { "guide": "Guide", "faq": "FAQ", "privacy": "Privacy" }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -31,5 +31,6 @@
     "category": "Catégorie",
     "categories": { "doctor":"Médecin", "clinic":"Clinique", "pharmacy":"Pharmacie", "other":"Autre" },
     "openInMaps": "Ouvrir dans Maps"
-  }
+  },
+  "footer": { "guide": "Guide", "faq": "FAQ", "privacy": "Confidentialité" }
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -31,5 +31,6 @@
     "category": "Категория",
     "categories": { "doctor":"Врач", "clinic":"Клиника", "pharmacy":"Аптека", "other":"Другое" },
     "openInMaps": "Открыть в Картах"
-  }
+  },
+  "footer": { "guide": "Руководство", "faq": "ЧАВО", "privacy": "Конфиденциальность" }
 }

--- a/tests/pages/Sos.test.jsx
+++ b/tests/pages/Sos.test.jsx
@@ -1,5 +1,5 @@
+// @vitest-environment jsdom
 import { render, fireEvent, screen } from "@testing-library/react";
-import "@testing-library/jest-dom";
 import { describe, it, expect, vi } from "vitest";
 import Sos from "../../src/pages/Sos";
 


### PR DESCRIPTION
## Summary
- replace App.jsx with full routing for Home/Profile/Meds/Visits/Calendar/Vitals/Nearby/SOS/FAQ/Privacy/Guide
- add LanguageSwitcher in header and rectangular SOS page button
- localize footer links (Guide/FAQ/Privacy) across en/ru/fr translations
- adjust SOS test to run in jsdom

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0752d94908323aae9c5ef4d0b84e9