### PR TITLE
feat: track vitals in single form

### DIFF
--- a/src/pages/Vitals.jsx
+++ b/src/pages/Vitals.jsx
@@ -3,74 +3,169 @@ import { useTranslation } from "react-i18next";
 import { maybeSendDailySummary } from "../lib/dailySummary.js";
 import { load, save } from "../lib/storage.js";
 
-const todayStr = () => new Date().toISOString().slice(0, 10);
-const timeStr  = () => new Date().toTimeString().slice(0,5);
-const newId = () => (crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(36) + Math.random().toString(36).slice(2));
+const nowStr = () => {
+  const d = new Date();
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 16);
+};
+
+const newId = () =>
+  crypto.randomUUID
+    ? crypto.randomUUID()
+    : Date.now().toString(36) + Math.random().toString(36).slice(2);
 
 export default function Vitals() {
   const { t } = useTranslation();
   const [items, setItems] = useState(() => {
-    const data = load("carebee.vitals", []);
+    const data = load("carebee:vitals", []);
     let changed = false;
-    const withIds = data.map(it => {
-      if (!it.id) { changed = true; return { ...it, id: newId() }; }
+    const withIds = data.map((it) => {
+      if (!it.id) {
+        changed = true;
+        return { ...it, id: newId() };
+      }
       return it;
     });
-    if (changed) save("carebee.vitals", withIds);
+    if (changed) save("carebee:vitals", withIds);
     return withIds;
   });
-  const [form, setForm]   = useState({ type: "hr", value: "", date: todayStr(), time: timeStr(), notes: "" });
 
+  const emptyForm = () => ({
+    datetime: nowStr(),
+    temp: "",
+    sys: "",
+    dia: "",
+    pulse: "",
+    spo2: "",
+    weight: "",
+    notes: "",
+  });
+
+  const [form, setForm] = useState(emptyForm);
   const onChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
 
   const add = (e) => {
     e.preventDefault();
-    const next = [...items, { id: newId(), ...form }];
-    next.sort((a,b)=> (a.date+a.time).localeCompare(b.date+b.time));
-    setItems(next); save("carebee.vitals", next);
+    const rec = { id: newId(), ...form };
+    const next = [...items, rec];
+    next.sort((a, b) => a.datetime.localeCompare(b.datetime));
+    setItems(next);
+    save("carebee:vitals", next);
     maybeSendDailySummary();
-    setForm({ type: form.type, value:"", date: todayStr(), time: timeStr(), notes:"" });
+    setForm(emptyForm());
   };
 
   const del = (id) => {
-    const next = items.filter(r => r.id !== id);
-    setItems(next); save("carebee.vitals", next);
+    const next = items.filter((r) => r.id !== id);
+    setItems(next);
+    save("carebee:vitals", next);
   };
 
   return (
     <div className="container">
-      <h1>{t("vitals.title","Vitals")}</h1>
+      <h1>{t("vitals.title", "Vitals")}</h1>
 
       <div className="card mb-4">
-        <form onSubmit={add} className="grid gap-3 md:grid-cols-4">
-          <select className="select" name="type" value={form.type} onChange={onChange}>
-            <option value="hr">{t("vitals.hr","Heart rate (bpm)")}</option>
-            <option value="temp">{t("vitals.temp","Temperature (°C)")}</option>
-            <option value="sys">{t("vitals.sys","Systolic (mmHg)")}</option>
-            <option value="dia">{t("vitals.dia","Diastolic (mmHg)")}</option>
-          </select>
-          <input className="input" name="value" type="number" step="any" required
-                 placeholder={t("fields.value")} value={form.value} onChange={onChange} />
-          <input className="input" name="date" type="date" value={form.date} onChange={onChange} />
-          <input className="input" name="time" type="time" value={form.time} onChange={onChange} />
-          <input className="input md:col-span-4" name="notes" placeholder={t("fields.notes")} value={form.notes} onChange={onChange} />
-          <div className="md:col-span-4">
-            <button className="btn btn-primary" type="submit">{t("vitals.add","Add measurement")}</button>
+        <form onSubmit={add} className="grid gap-3 md:grid-cols-2">
+          <input
+            className="input md:col-span-2"
+            type="datetime-local"
+            name="datetime"
+            value={form.datetime}
+            onChange={onChange}
+          />
+          <input
+            className="input"
+            type="number"
+            step="any"
+            name="temp"
+            placeholder={t("vitals.temp", "Temperature")}
+            value={form.temp}
+            onChange={onChange}
+          />
+          <div className="flex gap-2">
+            <input
+              className="input"
+              type="number"
+              step="any"
+              name="sys"
+              placeholder={t("vitals.sys", "Systolic")}
+              value={form.sys}
+              onChange={onChange}
+            />
+            <input
+              className="input"
+              type="number"
+              step="any"
+              name="dia"
+              placeholder={t("vitals.dia", "Diastolic")}
+              value={form.dia}
+              onChange={onChange}
+            />
+          </div>
+          <input
+            className="input"
+            type="number"
+            step="any"
+            name="pulse"
+            placeholder={t("vitals.pulse", "Pulse")}
+            value={form.pulse}
+            onChange={onChange}
+          />
+          <input
+            className="input"
+            type="number"
+            step="any"
+            name="spo2"
+            placeholder={t("vitals.spo2", "SpO₂")}
+            value={form.spo2}
+            onChange={onChange}
+          />
+          <input
+            className="input"
+            type="number"
+            step="any"
+            name="weight"
+            placeholder={t("vitals.weight", "Weight")}
+            value={form.weight}
+            onChange={onChange}
+          />
+          <input
+            className="input md:col-span-2"
+            name="notes"
+            placeholder={t("fields.notes", "Notes")}
+            value={form.notes}
+            onChange={onChange}
+          />
+          <div className="md:col-span-2">
+            <button className="btn btn-primary" type="submit">
+              {t("vitals.add", "Add measurement")}
+            </button>
           </div>
         </form>
       </div>
 
       {!items.length ? (
-        <div className="card muted">{t("vitals.empty","No vitals recorded yet")}</div>
+        <div className="card muted">
+          {t("vitals.empty", "No vitals recorded yet")}
+        </div>
       ) : (
         <ul className="grid gap-2">
-          {items.map(r => (
+          {items.map((r) => (
             <li key={r.id} className="card flex items-start justify-between">
-              <div>
-                <div className="font-medium">{r.date} {r.time} — {r.type.toUpperCase()}: {r.value}</div>
-                {r.notes ? <div className="muted text-sm">{r.notes}</div> : null}
+              <div className="font-medium">
+                {r.datetime} — {t("vitals.temp", "T")}: {r.temp}, BP: {r.sys}/
+                {r.dia}, {t("vitals.pulse", "Pulse")}: {r.pulse}, SpO₂: {r.spo2},
+                {" "}
+                {t("vitals.weight", "Weight")}: {r.weight}
+                {r.notes ? ` — ${r.notes}` : ""}
               </div>
-              <button className="btn btn-danger" onClick={()=>del(r.id)}>{t("actions.delete","Delete")}</button>
+              <button
+                className="btn btn-danger"
+                onClick={() => del(r.id)}
+              >
+                {t("actions.delete", "Delete")}
+              </button>
             </li>
           ))}
         </ul>
@@ -78,3 +173,4 @@ export default function Vitals() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- Replace Vitals page with single-form entry collecting timestamp, temp, BP, pulse, SpO₂, weight, and notes
- Store each record as one object in localStorage under `carebee:vitals` and allow deletion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b091a6209c832380855f73a8e2b46b