### PR TITLE
ci: assert build output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,11 @@ jobs:
           echo "=== LAST 200 LINES OF BUILD LOG ==="
           tail -n 200 build.log
 
+      - name: Assert dist exists
+        run: |
+          echo "Checking dist…"
+          test -d dist && test -f dist/index.html || (echo "dist not found" && exit 1)
+
       # Проверим, попало ли видео в dist
       - name: List dist after build
         run: |


### PR DESCRIPTION
## Summary
- assert dist output exists in deploy workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e19944e08323ae10fe02061578ca